### PR TITLE
Fix glibc CVE-2026-5450/-5928 across base images

### DIFF
--- a/Dockerfile.go-1.25-base
+++ b/Dockerfile.go-1.25-base
@@ -1,6 +1,7 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31
 
-RUN apk update && apk add --no-cache go-1.25 bash build-base git
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache go-1.25 bash build-base git
 
 USER nonroot
 WORKDIR /workspace

--- a/Dockerfile.nodejs-24-base
+++ b/Dockerfile.nodejs-24-base
@@ -1,7 +1,8 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS builder
 
 # Install Node.js, npm and Yarn
-RUN apk update && apk add --no-cache 'nodejs=~24' yarn npm
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache 'nodejs=~24' yarn npm
 
 # Extract Node.js version and save to file
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]

--- a/Dockerfile.python-3.13-base
+++ b/Dockerfile.python-3.13-base
@@ -1,7 +1,9 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS builder
 
 # CVE-2026-3644: requires python-3.13 >= 3.13.12-r7
-RUN apk update && apk add --no-cache --upgrade python-3.13 py3.13-pip uv && \
+# CVE-2026-5450/5928: glibc >= 2.43-r7 (forced via apk upgrade)
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache --upgrade python-3.13 py3.13-pip uv && \
     ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
     ln -sf /usr/bin/python3.13 /usr/bin/python
 

--- a/Dockerfile.python-3.14-base
+++ b/Dockerfile.python-3.14-base
@@ -1,6 +1,8 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:3258be472764337fd13095bcbb3182da170243b5819fd67ad4c0754590588b31 AS builder
 
-RUN apk update && apk add --no-cache --upgrade python-3.14 py3.14-pip uv && \
+# CVE-2026-5450/5928: glibc >= 2.43-r7 (forced via apk upgrade)
+RUN apk update && apk upgrade --no-cache && \
+    apk add --no-cache --upgrade python-3.14 py3.14-pip uv && \
     ln -sf /usr/bin/python3.14 /usr/bin/python3 && \
     ln -sf /usr/bin/python3.14 /usr/bin/python
 


### PR DESCRIPTION
## Summary

Force `apk upgrade --no-cache` in 4 Dockerfiles to pull glibc `2.43-r7` (was `2.43-r6` from the wolfi-base layer). Fixes 8 fixable MEDIUM CVEs surfaced by Trivy on `python-3.14-base` and applies to all sister images that derive from `wolfi-base@3258be4`.

**CVEs fixed:**
- CVE-2026-5450 — glibc heap buffer overflow in `scanf` with `%mc`
- CVE-2026-5928 — glibc info disclosure / DoS in `ungetwc`

**Affected packages bumped to 2.43-r7:** `glibc`, `glibc-locale-posix`, `ld-linux`, `libcrypt1`

**Why `apk upgrade`:** the wolfi-base SHA pinned in `FROM` is already at Chainguard's `latest` digest — Chainguard hasn't republished `wolfi-base:latest` with the fix yet. Wolfi's apk repo, however, has `2.43-r7` available now. `apk upgrade --no-cache` after `apk update` pulls the patched packages from the apk repo at build time.

## Files changed

- `Dockerfile.python-3.14-base`
- `Dockerfile.python-3.13-base`
- `Dockerfile.nodejs-24-base`
- `Dockerfile.go-1.25-base`

`Dockerfile.openjdk-17-base` already lists glibc explicitly in `apk add --upgrade`, so a rebuild picks up r7 without changes. `Dockerfile.wolfi-base` has no apk steps and will heal once Chainguard republishes the base image.

## Local verification

| Image | glibc installed | Trivy MEDIUM+ glibc findings |
|---|---|---|
| python-3.14-base | 2.43-r7 | 0 |
| python-3.13-base | 2.43-r7 | 0 |
| nodejs-24-base | 2.43-r7 | 0 |
| go-1.25-base | 2.43-r7 | 0 |
| openjdk-17-base | 2.43-r7 | 0 |

Trivy run with the same flags as CI: `--severity MEDIUM,HIGH,CRITICAL --ignore-unfixed --platform linux/amd64`.

## Test plan

- [x] Local `docker build --pull --platform linux/amd64` succeeds for all 4 changed Dockerfiles
- [x] Each built image reports `glibc-2.43-r7` for all 4 packages
- [x] Trivy `MEDIUM,HIGH,CRITICAL --ignore-unfixed`: 0 fixable glibc findings
- [x] CI build + scan passes on this PR
- [x] After merge: rebuild workflow tags + publishes new versions

## Out of scope (upstream-blocked, tracked separately)

- `nodejs-24-base`: 5 CVEs in npm/yarn bundled `@xmldom/xmldom` and `uuid`. Image already at latest Wolfi packages; awaits Wolfi rebuild.
- `go-1.25-base`: 6 CVEs flagged in stdlib via SBOM (Wolfi `go-1.25-1.25.9-r0` package contains 2 stdlib references still at go1.25.8). Awaits Wolfi rebuild with consistent stdlib.