### PR TITLE
Fix four failing release builds and harden workflows

### DIFF
--- a/.github/actions/extract-versions/action.yml
+++ b/.github/actions/extract-versions/action.yml
@@ -27,11 +27,16 @@ runs:
     - name: Extract versions from container
       id: extract
       shell: bash
+      env:
+        INPUT_IMAGE_BASE_NAME: ${{ inputs.image-base-name }}
+        INPUT_IMAGE_TAG: ${{ inputs.image-tag }}
+        INPUT_PLATFORM: ${{ inputs.platform }}
+        INPUT_PLATFORM_SUFFIX: ${{ inputs.platform-suffix }}
       run: |
-        image_base_name="${{ inputs.image-base-name }}"
-        test_tag="${{ inputs.image-tag }}"
-        platform="${{ inputs.platform }}"
-        platform_suffix="${{ inputs.platform-suffix }}"
+        image_base_name="$INPUT_IMAGE_BASE_NAME"
+        test_tag="$INPUT_IMAGE_TAG"
+        platform="$INPUT_PLATFORM"
+        platform_suffix="$INPUT_PLATFORM_SUFFIX"
         output_file="env.versions.${platform_suffix}"
         extraction_status="false"
 

--- a/.github/actions/parse-image-context/action.yml
+++ b/.github/actions/parse-image-context/action.yml
@@ -46,9 +46,13 @@ runs:
     - name: Parse tag and construct image context
       id: parse
       shell: bash
+      env:
+        INPUT_TAG: ${{ inputs.tag }}
+        INPUT_PLATFORM: ${{ inputs.platform }}
+        INPUT_FALLBACK_IMAGE: ${{ inputs.fallback-image }}
       run: |
-        tag_to_parse="${{ inputs.tag }}"
-        platform="${{ inputs.platform }}"
+        tag_to_parse="$INPUT_TAG"
+        platform="$INPUT_PLATFORM"
 
         echo "Input TAG: $tag_to_parse"
         echo "Input PLATFORM: $platform"
@@ -69,7 +73,7 @@ runs:
             version_no_build=$(echo "$version" | sed 's/\+.*//')
             is_release_tag="true"
 
-            # Extract major/minor version tags from semver (e.g., v1.1.108 → v1, v1.1)
+            # Extract major/minor version tags from semver (e.g., v1.1.108 -> v1, v1.1)
             if [[ $version_no_build =~ ^v([0-9]+)\.([0-9]+)\. ]]; then
                 major_tag="v${BASH_REMATCH[1]}"
                 minor_tag="v${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
@@ -91,7 +95,7 @@ runs:
         else
             # Not a release tag - use fallback
             echo "Not a release tag build. Using fallback values."
-            image_base_name="${{ inputs.fallback-image }}"
+            image_base_name="$INPUT_FALLBACK_IMAGE"
             version="dev"
             is_release_tag="false"
 

--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -41,6 +41,10 @@ runs:
     - name: Generate cache key
       id: cache-key
       shell: bash
+      env:
+        INPUT_PLATFORM: ${{ inputs.platform }}
+        REPOSITORY: ${{ github.repository }}
+        RUNNER_OS_NAME: ${{ runner.os }}
       run: |
-        platform_safe=$(echo "${{ inputs.platform }}" | sed 's/\//-/g')
-        echo "key=${{ github.repository }}-docker-${{ runner.os }}-${platform_safe}" >> $GITHUB_OUTPUT
+        platform_safe=$(echo "$INPUT_PLATFORM" | sed 's/\//-/g')
+        echo "key=${REPOSITORY}-docker-${RUNNER_OS_NAME}-${platform_safe}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -1,19 +1,31 @@
 name: Auto-approve Renovate PRs
 
+# pull_request rather than pull_request_target: Renovate opens its PRs from
+# in-repo branches (renovate/*), never forks, so secrets and write access are
+# already available here without handing them to untrusted fork code. A fork PR
+# that somehow reached this workflow would get a read-only token and no secrets,
+# so it fails closed instead of auto-approving.
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize
       - reopened
 
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
-    if: github.actor == 'renovate[bot]' || github.actor == 'renovate'
+    permissions:
+      contents: read
+      pull-requests: write
+    # Gate on the author's immutable numeric id, not github.actor. actor is
+    # whoever triggered the event - a synchronize can be a different account -
+    # and a login string can be freed up and re-registered. 29139614 is the
+    # renovate[bot] app user.
+    if: github.event.pull_request.user.id == 29139614
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -6,15 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege by default; only the tag-pushing job widens contents.
 permissions:
-  actions: read
-  contents: write
-  packages: write
-  security-events: write
+  contents: read
 
 jobs:
   detect_changed_images:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       images_matrix: ${{ steps.build_matrix.outputs.images_to_build }}
       has_changes: ${{ steps.build_matrix.outputs.has_changes }}
@@ -31,6 +31,9 @@ jobs:
         with:
           token: "${{ secrets.PAT_TOKEN }}"
           fetch-depth: 0
+          # Tag pushes below authenticate explicitly via url.insteadOf, so the
+          # checkout credential does not need to persist into the work tree.
+          persist-credentials: false
 
       - name: Detect changed Dockerfiles and build matrix
         id: build_matrix
@@ -83,6 +86,8 @@ jobs:
     needs: detect_changed_images
     if: needs.detect_changed_images.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # pushes release tags
     strategy:
       fail-fast: false
       matrix:
@@ -100,18 +105,25 @@ jobs:
         with:
           token: "${{ secrets.PAT_TOKEN }}"
           fetch-depth: 0
+          # Tag pushes below authenticate explicitly via url.insteadOf, so the
+          # checkout credential does not need to persist into the work tree.
+          persist-credentials: false
 
       - name: Display processing image
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
         run: |
-          echo "Processing image: ${{ matrix.image_name }}"
+          echo "Processing image: $IMAGE_NAME"
 
       - name: Find latest tag for image
         id: latest_tag
+        env:
+          IMAGE_NAME: ${{ matrix.image_name }}
         run: |
-          echo "Looking for existing tags for ${{ matrix.image_name }}..."
+          echo "Looking for existing tags for ${IMAGE_NAME}..."
           latest=$(git for-each-ref --sort='-v:refname' \
             --format '%(refname:short)' \
-            "refs/tags/release/${{ matrix.image_name }}" | head -n 1)
+            "refs/tags/release/${IMAGE_NAME}" | head -n 1)
 
           if [ -n "$latest" ]; then
             # Extract semver from tag (remove 'v' prefix)
@@ -131,16 +143,23 @@ jobs:
           version: ${{ steps.latest_tag.outputs.current_semver }}
 
       - name: Display version information
+        env:
+          CURRENT_SEMVER: ${{ steps.latest_tag.outputs.current_semver }}
+          NEXT_PATCH: ${{ steps.next_version.outputs.patch }}
+          NEXT_MINOR: ${{ steps.next_version.outputs.minor }}
+          NEXT_MAJOR: ${{ steps.next_version.outputs.major }}
         run: |
-          echo "Current version: ${{ steps.latest_tag.outputs.current_semver }}"
-          echo "Next patch version: ${{ steps.next_version.outputs.patch }}"
-          echo "Next minor version: ${{ steps.next_version.outputs.minor }}"
-          echo "Next major version: ${{ steps.next_version.outputs.major }}"
+          echo "Current version: $CURRENT_SEMVER"
+          echo "Next patch version: $NEXT_PATCH"
+          echo "Next minor version: $NEXT_MINOR"
+          echo "Next major version: $NEXT_MAJOR"
 
       - name: Create and push release tag
         if: github.event.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+          NEXT_PATCH: ${{ steps.next_version.outputs.patch }}
         run: |
           # Configure git for bot user
           git config user.email "i0-baseimages-bot@users.noreply.github.com"
@@ -150,8 +169,8 @@ jobs:
           git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
 
           # Create new tag with next patch version
-          new_tag="release/${{ matrix.image_name }}/v${{ steps.next_version.outputs.patch }}"
-          tag_message="Release ${{ matrix.image_name }}/v${{ steps.next_version.outputs.patch }}"
+          new_tag="release/${IMAGE_NAME}/v${NEXT_PATCH}"
+          tag_message="Release ${IMAGE_NAME}/v${NEXT_PATCH}"
 
           echo "Creating tag: $new_tag"
           echo "Tag message: $tag_message"
@@ -159,4 +178,4 @@ jobs:
           git tag -a "$new_tag" -m "$tag_message"
           git push origin "$new_tag"
 
-          echo "✅ Successfully created and pushed tag: $new_tag"
+          echo "[OK] Successfully created and pushed tag: $new_tag"

--- a/.github/workflows/daily-scan-and-rebuild.yml
+++ b/.github/workflows/daily-scan-and-rebuild.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           token: "${{ secrets.PAT_TOKEN }}"
           fetch-depth: 0 # Required to list tags
+          # The rebuild-tag push below authenticates explicitly via
+          # url.insteadOf, so the credential need not persist in the work tree.
+          persist-credentials: false
 
       - name: Discover available base images
         id: discover_images
@@ -65,7 +68,7 @@ jobs:
 
       - name: Install Trivy scanner
         env:
-          TRIVY_VERSION: "0.69.3"
+          TRIVY_VERSION: "0.72.0"
         run: |
           # Install Trivy (pinned version) and jq for vulnerability scanning
           sudo apt-get update && sudo apt-get install -y jq
@@ -112,7 +115,7 @@ jobs:
 
             for platform_suffix in linux-amd64 linux-arm64; do
               image_name="${base_name}-${platform_suffix}"
-              full_image_tag="${{ env.REGISTRY }}/${{ env.GH_REPO }}/${image_name}:latest"
+              full_image_tag="${REGISTRY}/${GH_REPO}/${image_name}:latest"
 
               echo "Checking image: $full_image_tag"
 
@@ -122,22 +125,22 @@ jobs:
                 continue # Skip to next platform
               fi
 
-              echo "Scanning $full_image_tag for vulnerabilities (severities: ${{ env.TRIGGER_SEVERITIES }})"
+              echo "Scanning $full_image_tag for vulnerabilities (severities: ${TRIGGER_SEVERITIES})"
               # Run Trivy vulnerability scan
               if trivy image \
                 --ignore-unfixed \
                 --exit-code 1 \
-                --severity "${{ env.TRIGGER_SEVERITIES }}" \
+                --severity "$TRIGGER_SEVERITIES" \
                 --format table \
                 "$full_image_tag"; then
-                echo "✅ No fixable vulnerabilities found in $full_image_tag"
+                echo "[OK] No fixable vulnerabilities found in $full_image_tag"
               else
                 scan_exit_code=$?
                 if [ $scan_exit_code -eq 1 ]; then
-                  echo "⚠️  Fixable vulnerabilities found in $full_image_tag"
+                  echo "[WARN] Fixable vulnerabilities found in $full_image_tag"
                   found_fixable_vulns_for_base=true
                 else
-                  echo "❌ Trivy scan failed for $full_image_tag (exit code: $scan_exit_code)"
+                  echo "[FAIL] Trivy scan failed for $full_image_tag (exit code: $scan_exit_code)"
                   # Continue processing other platforms
                 fi
               fi
@@ -145,7 +148,7 @@ jobs:
 
             # Check if we need to rebuild based on vulnerabilities + base image freshness
             if [ "$found_fixable_vulns_for_base" = true ]; then
-              echo "🔍 Vulnerabilities found for $base_name. Checking base image freshness..."
+              echo "[INFO] Vulnerabilities found for $base_name. Checking base image freshness..."
               dockerfile="Dockerfile.$base_name"
               if [ ! -f "$dockerfile" ]; then
                 echo "::error::Dockerfile $dockerfile not found. Cannot check base image. Skipping rebuild trigger for $base_name."
@@ -172,12 +175,12 @@ jobs:
                   if [ -n "$latest_sha_digest" ]; then
                     echo "Latest digest found: [$latest_sha_digest]"
                     if [ "$current_sha_digest" != "$latest_sha_digest" ]; then
-                      echo "🔄 Base image has updates: $latest_sha_digest vs $current_sha_digest"
+                      echo "[INFO] Base image has updates: $latest_sha_digest vs $current_sha_digest"
                       echo "Adding '$base_name' to rebuild list (vulnerabilities found + outdated base image)"
                       needs_rebuild_list="${needs_rebuild_list} ${base_name}"
                       rebuild_reason="Fixable vulnerabilities found and base image $from_image_name has updates."
                     else
-                      echo "✅ Base image [$from_image_name] is up-to-date. Skipping rebuild despite vulnerabilities."
+                      echo "[OK] Base image [$from_image_name] is up-to-date. Skipping rebuild despite vulnerabilities."
                       rebuild_reason="Fixable vulnerabilities found, but base image $from_image_name is already up-to-date."
                     fi
                   else
@@ -193,7 +196,7 @@ jobs:
                 rebuild_reason="Fixable vulnerabilities found, but could not parse FROM line in $dockerfile."
               fi
             else
-              echo "✅ No fixable vulnerabilities found for $base_name"
+              echo "[OK] No fixable vulnerabilities found for $base_name"
               rebuild_reason="No fixable vulnerabilities found."
             fi
 
@@ -210,12 +213,12 @@ jobs:
           unique_needs_rebuild=$(echo "$needs_rebuild_list" | xargs -n1 | sort -u | xargs)
 
           if [ -z "$unique_needs_rebuild" ]; then
-            echo "✅ No images require rebuilding based on vulnerability scans and base image freshness checks."
+            echo "[OK] No images require rebuilding based on vulnerability scans and base image freshness checks."
             echo "triggered_rebuilds=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "🚀 Triggering rebuilds for: $unique_needs_rebuild"
+          echo "[INFO] Triggering rebuilds for: $unique_needs_rebuild"
           echo "triggered_rebuilds=true" >> "$GITHUB_OUTPUT"
           echo "rebuild_list=$unique_needs_rebuild" >> "$GITHUB_OUTPUT"
 
@@ -236,7 +239,7 @@ jobs:
             echo "Latest release tag found: $latest_release_tag"
 
             # COOLDOWN CHECK: Skip if recently rebuilt (unless force or critical)
-            if [ "${{ github.event.inputs.ignore_cooldown }}" != "true" ]; then
+            if [ "$INPUT_IGNORE_COOLDOWN" != "true" ]; then
               # Get the commit timestamp of the latest tag
               tag_commit=$(git rev-list -n 1 "$latest_release_tag")
               tag_timestamp=$(git show -s --format=%ct "$tag_commit")
@@ -245,18 +248,18 @@ jobs:
 
               cooldown_hours="${REBUILD_COOLDOWN_HOURS:-72}"
 
-              echo "⏱️  Hours since last release for $base_name: $hours_since_last_release (cooldown: ${cooldown_hours}h)"
+              echo "[INFO] Hours since last release for $base_name: $hours_since_last_release (cooldown: ${cooldown_hours}h)"
 
               if [ "$hours_since_last_release" -lt "$cooldown_hours" ]; then
-                echo "⏸️  Skipping $base_name: Within ${cooldown_hours}h cooldown period"
+                echo "[SKIP] Skipping $base_name: Within ${cooldown_hours}h cooldown period"
                 echo "   Last release: $(date -d "@${tag_timestamp}" 2>/dev/null || date -r "${tag_timestamp}")"
                 echo "   Next eligible: $(date -d "@$((tag_timestamp + cooldown_hours * 3600))" 2>/dev/null || date -r "$((tag_timestamp + cooldown_hours * 3600))")"
                 continue
               else
-                echo "✅ $base_name passed cooldown check (${hours_since_last_release}h > ${cooldown_hours}h)"
+                echo "[OK] $base_name passed cooldown check (${hours_since_last_release}h > ${cooldown_hours}h)"
               fi
             else
-              echo "⚠️  Cooldown check skipped (ignore_cooldown=true)"
+              echo "[WARN] Cooldown check skipped (ignore_cooldown=true)"
             fi
 
             # Extract version and create rebuild tag
@@ -272,9 +275,11 @@ jobs:
             new_tag="release/${base_name}/${version_part_no_build}+rebuild.${timestamp}"
 
             echo "Creating and pushing rebuild tag: $new_tag"
+            git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
             git tag "$new_tag"
             git push origin "$new_tag"
-            echo "✅ Rebuild triggered for $base_name by pushing tag $new_tag"
+            echo "[OK] Rebuild triggered for $base_name by pushing tag $new_tag"
           done
         env:
           GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+          INPUT_IGNORE_COOLDOWN: ${{ github.event.inputs.ignore_cooldown }}

--- a/.github/workflows/manual-build-trigger.yml
+++ b/.github/workflows/manual-build-trigger.yml
@@ -26,6 +26,10 @@ on:
 env:
   REGISTRY: ghcr.io
 
+# Least privilege by default; only the tag-pushing job widens contents.
+permissions:
+  contents: read
+
 jobs:
   trigger_builds:
     runs-on: ubuntu-latest
@@ -33,9 +37,7 @@ jobs:
       has_images: ${{ steps.determine_images.outputs.has_images }}
       images_built: ${{ steps.determine_images.outputs.images_to_build }}
     permissions:
-      contents: write
-      packages: write
-      actions: read
+      contents: write # pushes release tags
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -47,6 +49,9 @@ jobs:
         with:
           fetch-depth: 0
           token: "${{ secrets.PAT_TOKEN }}"
+          # Tag pushes below authenticate explicitly via url.insteadOf, so the
+          # credential does not need to persist into the work tree.
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -55,14 +60,16 @@ jobs:
 
       - name: Determine images to build
         id: determine_images
+        env:
+          INPUT_IMAGES: ${{ github.event.inputs.images }}
         run: |
           images_to_build=()
-          if [ -z "${{ github.event.inputs.images }}" ]; then
+          if [ -z "$INPUT_IMAGES" ]; then
             echo "No images specified, building all images."
             mapfile -t images_to_build < <(find . -maxdepth 1 -name 'Dockerfile.*' -type f -printf '%f\n' | while IFS= read -r f; do echo "${f#Dockerfile.}"; done | sort -u)
           else
-            echo "Building specified images: ${{ github.event.inputs.images }}"
-            IFS=',' read -ra ADDR <<< "${{ github.event.inputs.images }}"
+            echo "Building specified images: $INPUT_IMAGES"
+            IFS=',' read -ra ADDR <<< "$INPUT_IMAGES"
             for i in "${ADDR[@]}"; do
               images_to_build+=("$i")
             done
@@ -79,7 +86,13 @@ jobs:
           fi
       - name: Create and push release tags
         if: steps.determine_images.outputs.has_images == 'true'
+        env:
+          IMAGES_TO_BUILD: ${{ steps.determine_images.outputs.images_to_build }}
+          INPUT_REASON: ${{ github.event.inputs.reason }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
+          git config --global url."https://x-access-token:${GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+
           # Function to increment patch version
           increment_version() {
             local version=$1
@@ -99,9 +112,9 @@ jobs:
             git tag -l "release/$image/v*" | sort -V | tail -1
           }
 
-          images="${{ steps.determine_images.outputs.images_to_build }}"
+          images="$IMAGES_TO_BUILD"
 
-          echo "🏷️  Creating release tags..."
+          echo "[INFO] Creating release tags..."
 
           for image in $images; do
             latest_tag=$(get_latest_tag "$image")
@@ -112,7 +125,7 @@ jobs:
             fi
 
             new_tag="release/$image/v$new_version"
-            commit_msg="Manual release $image v$new_version - ${{ github.event.inputs.reason }}"
+            commit_msg="Manual release $image v$new_version - $INPUT_REASON"
 
             echo "Creating tag: $new_tag"
             git tag -a "$new_tag" -m "$commit_msg"
@@ -120,29 +133,36 @@ jobs:
             echo "Pushing tag: $new_tag"
             git push origin "$new_tag"
 
-            echo "✅ Created and pushed: $new_tag"
+            echo "[OK] Created and pushed: $new_tag"
           done
 
       - name: Build summary
         if: steps.determine_images.outputs.has_images == 'true'
+        env:
+          IMAGES_TO_BUILD: ${{ steps.determine_images.outputs.images_to_build }}
+          INPUT_REASON: ${{ github.event.inputs.reason }}
+          INPUT_FORCE_ALL: ${{ github.event.inputs.force_all }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          images="${{ steps.determine_images.outputs.images_to_build }}"
+          images="$IMAGES_TO_BUILD"
           image_count=$(echo "$images" | wc -w)
 
           echo ""
-          echo "📊 Build Summary"
+          echo "[INFO] Build Summary"
           echo "================"
-          echo "Reason: ${{ github.event.inputs.reason }}"
+          echo "Reason: $INPUT_REASON"
           echo "Images triggered: $image_count"
-          echo "Force all: ${{ github.event.inputs.force_all }}"
+          echo "Force all: $INPUT_FORCE_ALL"
           echo ""
-          echo "🌐 Monitor builds at:"
-          echo "https://github.com/${{ github.repository }}/actions"
+          echo "[INFO] Monitor builds at:"
+          echo "https://github.com/${REPOSITORY}/actions"
 
   wait_for_completion:
     needs: trigger_builds
     runs-on: ubuntu-latest
     if: needs.trigger_builds.outputs.has_images == 'true'
+    permissions:
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -151,10 +171,10 @@ jobs:
 
       - name: Wait for workflow completion
         run: |
-          echo "⏱️  Triggered image builds will appear shortly in the Actions tab"
-          echo "🔗 https://github.com/${{ github.repository }}/actions"
+          echo "[INFO] Triggered image builds will appear shortly in the Actions tab"
+          echo "[INFO] https://github.com/${{ github.repository }}/actions"
           echo ""
-          echo "💡 Each release tag triggers a separate workflow run that will:"
+          echo "[INFO] Each release tag triggers a separate workflow run that will:"
           echo "   1. Build Docker images for both linux/amd64 and linux/arm64"
           echo "   2. Run security scans and tests"
           echo "   3. Create GitHub releases"

--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -297,10 +297,13 @@ jobs:
         env:
           IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
           IMAGE_REF: ${{ steps.test_image.outputs.image_ref }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
+          # --platform must be explicit: it defaults to the HOST architecture,
+          # so on an amd64 runner the arm64 image would fail to start.
           test_config="tests/container-structure/${IMAGE_BASE_NAME}.yaml"
           if [ -f "$test_config" ]; then
-            container-structure-test test --image "$IMAGE_REF" --config "$test_config"
+            container-structure-test test --platform "$PLATFORM" --image "$IMAGE_REF" --config "$test_config"
           else
             echo "No container structure test config found at $test_config, skipping tests"
           fi

--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -279,11 +279,14 @@ jobs:
       # tampered or silently-changed upload fails the build.
       - name: Install container-structure-test
         env:
+          # From the release's published checksums.txt, verified against an
+          # independently downloaded binary. The GCS bucket only serves
+          # "latest", so the pinned artifact comes from the GitHub release.
           CST_VERSION: v1.22.1
-          CST_SHA256: 0c457d0ca6ab964bb7b8994a501bf954768e80ed59a0c500412b235d13362b11
+          CST_SHA256: fa35e89512a8978585f76cf41397956d2e3a30c62c2ad3fb857b1597074d14ca
         run: |
           set -euo pipefail
-          url="https://storage.googleapis.com/container-structure-test/${CST_VERSION}/container-structure-test-linux-amd64"
+          url="https://github.com/GoogleContainerTools/container-structure-test/releases/download/${CST_VERSION}/container-structure-test-linux-amd64"
           curl -fsSL -o container-structure-test "$url"
           echo "${CST_SHA256}  container-structure-test" | sha256sum -c -
           chmod +x container-structure-test

--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -14,9 +14,15 @@ env:
   REGISTRY: ghcr.io
   TAG: ${{ github.ref }}
 
+# Least privilege by default; individual jobs widen only what they need.
+permissions:
+  contents: read
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       image-base-name: ${{ steps.context.outputs.image-base-name }}
       is_deprecated: ${{ steps.image_deprecation_check.outputs.is_deprecated }}
@@ -33,18 +39,24 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0 # Needed for git diff in PRs
+          persist-credentials: false
 
       - name: Set Tag and Detect Image for PR
         id: set-tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF_NAME_FULL: ${{ github.ref }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            modified_dockerfile=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" | grep "^Dockerfile\\." | head -n 1)
+          if [ "$EVENT_NAME" == "pull_request" ]; then
+            modified_dockerfile=$(git diff --name-only "$PR_BASE_SHA" "$HEAD_SHA" | grep "^Dockerfile\\." | head -n 1)
             if [ -n "$modified_dockerfile" ]; then
               detected_image="${modified_dockerfile#Dockerfile.}"
               if [[ "$detected_image" == "go-base" || "$detected_image" == "nodejs-base" || "$detected_image" == "python-base" ]]; then
                 echo "PR modifies a deprecated image ($detected_image). Halting build for this image."
                 echo "dockerfile_found=false" >> "$GITHUB_OUTPUT"
-                echo "tag=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+                echo "tag=$GITHUB_REF_NAME_FULL" >> "$GITHUB_OUTPUT"
               else
                 detected_tag="release/${detected_image}/v0.0.0-pr"
                 echo "dockerfile_found=true" >> "$GITHUB_OUTPUT"
@@ -53,12 +65,12 @@ jobs:
               fi
             else
               echo "dockerfile_found=false" >> "$GITHUB_OUTPUT"
-              echo "tag=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+              echo "tag=$GITHUB_REF_NAME_FULL" >> "$GITHUB_OUTPUT"
               echo "No Dockerfile changes detected in PR, will exit early"
             fi
           else
             echo "dockerfile_found=true" >> "$GITHUB_OUTPUT"
-            echo "tag=${{ github.ref }}" >> "$GITHUB_OUTPUT"
+            echo "tag=$GITHUB_REF_NAME_FULL" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Parse image context
@@ -70,9 +82,12 @@ jobs:
 
       - name: Check for deprecated image after parsing
         id: image_deprecation_check
+        env:
+          IMAGE_BASE_NAME: ${{ steps.context.outputs.image-base-name }}
+          RESOLVED_TAG: ${{ steps.set-tag.outputs.tag }}
         run: |
-           if [ "${{ steps.context.outputs.image-base-name }}" == "__UNDEFINED__" ]; then
-             echo "Deprecated or invalid image detected for tag ${{ steps.set-tag.outputs.tag }}. Skipping build."
+           if [ "$IMAGE_BASE_NAME" == "__UNDEFINED__" ]; then
+             echo "Deprecated or invalid image detected for tag ${RESOLVED_TAG}. Skipping build."
              echo "is_deprecated=true" >> "$GITHUB_OUTPUT"
            else
              echo "is_deprecated=false" >> "$GITHUB_OUTPUT"
@@ -111,6 +126,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Parse image context
         id: context
@@ -121,8 +137,10 @@ jobs:
 
       - name: Check if Dockerfile exists
         id: file_check
+        env:
+          IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
         run: |
-          dockerfile_path="Dockerfile.${{ needs.generate-matrix.outputs.image-base-name }}"
+          dockerfile_path="Dockerfile.${IMAGE_BASE_NAME}"
           if [ -f "$dockerfile_path" ]; then
             echo "dockerfile_exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -131,19 +149,25 @@ jobs:
 
       - name: Exit early if Dockerfile does not exist
         if: steps.file_check.outputs.dockerfile_exists != 'true'
+        env:
+          IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
         run: |
-          echo "Dockerfile for ${{ needs.generate-matrix.outputs.image-base-name }} does not exist. Halting build."
+          echo "Dockerfile for ${IMAGE_BASE_NAME} does not exist. Halting build."
           exit 0
 
       - name: Check if Dockerfile changed for this image
         id: dockerfile_check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF_TYPE: ${{ github.ref_type }}
+          IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
         run: |
-          if [[ "${{ github.event_name }}" != "push" || "${{ github.ref_type }}" != "tag" ]]; then
+          if [[ "$EVENT_NAME" != "push" || "$REF_TYPE" != "tag" ]]; then
             echo "dockerfile_changed=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          dockerfile_path="Dockerfile.${{ needs.generate-matrix.outputs.image-base-name }}"
-          prev_tag=$(git tag -l "release/${{ needs.generate-matrix.outputs.image-base-name }}/v*" --sort=-version:refname | sed -n '2p')
+          dockerfile_path="Dockerfile.${IMAGE_BASE_NAME}"
+          prev_tag=$(git tag -l "release/${IMAGE_BASE_NAME}/v*" --sort=-version:refname | sed -n '2p')
           if [ -n "$prev_tag" ]; then
             if git diff --name-only "$prev_tag" HEAD | grep -q "^${dockerfile_path}$"; then
               echo "dockerfile_changed=true" >> "$GITHUB_OUTPUT"
@@ -163,9 +187,13 @@ jobs:
       - name: Check if image already exists for this tag
         if: github.event_name == 'push' && github.ref_type == 'tag'
         id: image_exists
+        env:
+          REPOSITORY: ${{ github.repository }}
+          CTX_IMAGE_NAME: ${{ steps.context.outputs.image-name }}
+          VERSION_NO_BUILD: ${{ steps.context.outputs.version-no-build }}
         run: |
-          image_name="${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.context.outputs.image-name }}"
-          tag="${{ steps.context.outputs.version-no-build }}"
+          image_name="${REGISTRY}/${REPOSITORY}/${CTX_IMAGE_NAME}"
+          tag="$VERSION_NO_BUILD"
           if docker manifest inspect "$image_name:$tag" >/dev/null 2>&1; then
             echo "image_exists=true" >> "$GITHUB_OUTPUT"
           else
@@ -217,42 +245,59 @@ jobs:
           provenance: false
           sbom: false
           cache-from: type=gha,scope=${{ github.repository }}-${{ needs.generate-matrix.outputs.image-base-name }}
-          cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ needs.generate-matrix.outputs.image-base-name }}
+          # ignore-error: cache export is an optimisation, not a correctness gate.
+          # GHA cache eviction under the ~10GB repo budget surfaces as
+          # "error writing layer blob: not_found" and must not fail a release build.
+          cache-to: type=gha,mode=max,ignore-error=true,scope=${{ github.repository }}-${{ needs.generate-matrix.outputs.image-base-name }}
 
       - name: Set test image reference
         id: test_image
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          IMAGE_NAME: ${{ steps.context.outputs.image-name }}
+          VERSION_NO_BUILD: ${{ steps.context.outputs.version-no-build }}
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
-            echo "image_ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.context.outputs.image-name }}:test" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" == "pull_request" ]; then
+            echo "image_ref=${REGISTRY}/${REPOSITORY}/${IMAGE_NAME}:test" >> "$GITHUB_OUTPUT"
           else
-            echo "image_ref=${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.context.outputs.image-name }}:${{ steps.context.outputs.version-no-build }}" >> "$GITHUB_OUTPUT"
+            echo "image_ref=${REGISTRY}/${REPOSITORY}/${IMAGE_NAME}:${VERSION_NO_BUILD}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Output Docker Image Size for ${{ matrix.platform }}
+        env:
+          IMAGE_REF: ${{ steps.test_image.outputs.image_ref }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
-          size=$(docker images --format "table {{.Size}}" "${{ steps.test_image.outputs.image_ref }}" | tail -n +2)
-          echo "Docker image size for ${{ matrix.platform }}: $size"
+          size=$(docker images --format "table {{.Size}}" "$IMAGE_REF" | tail -n +2)
+          echo "Docker image size for ${PLATFORM}: $size"
 
-      - name: Cache container-structure-test
-        id: cst-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: /usr/local/bin/container-structure-test
-          key: cst-${{ runner.os }}-latest
-
+      # Not cached: a restored cache entry is attacker-influenceable on a
+      # tag-triggered publish (cache poisoning), and the test binary is small
+      # enough that re-downloading it is cheaper than defending the cache.
+      # Pinned and checksum-verified instead of tracking "latest", so a
+      # tampered or silently-changed upload fails the build.
       - name: Install container-structure-test
-        if: steps.cst-cache.outputs.cache-hit != 'true'
+        env:
+          CST_VERSION: v1.22.1
+          CST_SHA256: 0c457d0ca6ab964bb7b8994a501bf954768e80ed59a0c500412b235d13362b11
         run: |
-          curl -LO https://storage.googleapis.com/container-structure-test/latest/container-structure-test-linux-amd64
-          chmod +x container-structure-test-linux-amd64
-          sudo mv container-structure-test-linux-amd64 /usr/local/bin/container-structure-test
+          set -euo pipefail
+          url="https://storage.googleapis.com/container-structure-test/${CST_VERSION}/container-structure-test-linux-amd64"
+          curl -fsSL -o container-structure-test "$url"
+          echo "${CST_SHA256}  container-structure-test" | sha256sum -c -
+          chmod +x container-structure-test
+          sudo mv container-structure-test /usr/local/bin/container-structure-test
+          container-structure-test version
 
       - name: Run Container Structure Tests for ${{ matrix.platform }}
+        env:
+          IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
+          IMAGE_REF: ${{ steps.test_image.outputs.image_ref }}
         run: |
-          image_base_name="${{ needs.generate-matrix.outputs.image-base-name }}"
-          test_config="tests/container-structure/${image_base_name}.yaml"
+          test_config="tests/container-structure/${IMAGE_BASE_NAME}.yaml"
           if [ -f "$test_config" ]; then
-            container-structure-test test --image "${{ steps.test_image.outputs.image_ref }}" --config "$test_config"
+            container-structure-test test --image "$IMAGE_REF" --config "$test_config"
           else
             echo "No container structure test config found at $test_config, skipping tests"
           fi
@@ -262,6 +307,7 @@ jobs:
         with:
           scan-type: image
           image-ref: ${{ steps.test_image.outputs.image_ref }}
+          version: v0.72.0
           format: table
           exit-code: "1"
           ignore-unfixed: true
@@ -344,6 +390,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
 
       - name: Parse tag for release info
         id: parse_tag_release
@@ -361,10 +409,14 @@ jobs:
 
       - name: Create GitHub Release Body
         id: release_body
+        env:
+          CTX_IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
+          CTX_VERSION_TAG: ${{ needs.publish_image.outputs.version }}
+          CTX_REPOSITORY: ${{ github.repository }}
         run: |
-          image_base_name="${{ needs.generate-matrix.outputs.image-base-name }}"
-          version_tag="${{ needs.publish_image.outputs.version }}"
-          repo_name="${{ github.repository }}"
+          image_base_name="$CTX_IMAGE_BASE_NAME"
+          version_tag="$CTX_VERSION_TAG"
+          repo_name="$CTX_REPOSITORY"
           registry="${{ env.REGISTRY }}"
 
           # Use a temporary file to construct the body
@@ -402,7 +454,7 @@ jobs:
           docker build --pull -t your-app .
           \`\`\`
 
-          **🔐 Build Provenance & Supply Chain Security:**
+          **Build Provenance & Supply Chain Security:**
 
           Platform-specific images include full SLSA provenance attestations (\`provenance: mode=max\`) and SBOM.
 
@@ -449,16 +501,27 @@ jobs:
 
           rm -f "$RELEASE_BODY_FILE" # Clean up temporary file
 
+      # Uses the runner's bundled gh rather than a third-party release action,
+      # removing one external dependency from the publish path. Idempotent so a
+      # re-run against an existing tag updates the release instead of failing.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: "Release ${{ needs.generate-matrix.outputs.image-base-name }} ${{ steps.parse_tag_release.outputs.version }}"
-          body: ${{ env.BODY_TEXT }}
-          draft: false
-          prerelease: ${{ contains(steps.parse_tag_release.outputs.version, '-') }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TITLE: Release ${{ needs.generate-matrix.outputs.image-base-name }} ${{ steps.parse_tag_release.outputs.version }}
+          IS_PRERELEASE: ${{ contains(steps.parse_tag_release.outputs.version, '-') }}
+        run: |
+          set -euo pipefail
+          args=(--title "$RELEASE_TITLE" --notes "$BODY_TEXT")
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            args+=(--prerelease)
+          fi
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; updating it."
+            gh release edit "$RELEASE_TAG" "${args[@]}"
+          else
+            gh release create "$RELEASE_TAG" "${args[@]}"
+          fi
 
   create_multiarch_manifests:
     needs: [generate-matrix, publish_image, create_release]
@@ -479,6 +542,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
       - name: Log in to Container Registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
@@ -486,10 +551,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create multi-arch manifests
+        env:
+          CTX_IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
+          CTX_VERSION: ${{ needs.publish_image.outputs.version }}
+          CTX_REPOSITORY: ${{ github.repository }}
+          CTX_HAS_VERSION_TAGS: ${{ needs.publish_image.outputs.has-version-tags }}
+          CTX_MAJOR_TAG: ${{ needs.publish_image.outputs.major-tag }}
+          CTX_MINOR_TAG: ${{ needs.publish_image.outputs.minor-tag }}
         run: |
-          image_base_name="${{ needs.generate-matrix.outputs.image-base-name }}"
-          version="${{ needs.publish_image.outputs.version }}"
-          registry="${{ env.REGISTRY }}/${{ github.repository }}"
+          image_base_name="$CTX_IMAGE_BASE_NAME"
+          version="$CTX_VERSION"
+          registry="${{ env.REGISTRY }}/${CTX_REPOSITORY}"
 
           echo "Creating multi-arch manifests for $image_base_name"
 
@@ -500,14 +572,14 @@ jobs:
 
           echo "Checking if source images exist:"
           echo "AMD64: $amd64_image:$version"
-          docker manifest inspect "$amd64_image:$version" >/dev/null && echo "✅ AMD64 image exists" || echo "❌ AMD64 image missing"
+          docker manifest inspect "$amd64_image:$version" >/dev/null && echo "[OK] AMD64 image exists" || echo "[FAIL] AMD64 image missing"
           echo "ARM64: $arm64_image:$version"
-          docker manifest inspect "$arm64_image:$version" >/dev/null && echo "✅ ARM64 image exists" || echo "❌ ARM64 image missing"
+          docker manifest inspect "$arm64_image:$version" >/dev/null && echo "[OK] ARM64 image exists" || echo "[FAIL] ARM64 image missing"
 
           echo "AMD64: $amd64_image:latest"
-          docker manifest inspect "$amd64_image:latest" >/dev/null && echo "✅ AMD64 latest exists" || echo "❌ AMD64 latest missing"
+          docker manifest inspect "$amd64_image:latest" >/dev/null && echo "[OK] AMD64 latest exists" || echo "[FAIL] AMD64 latest missing"
           echo "ARM64: $arm64_image:latest"
-          docker manifest inspect "$arm64_image:latest" >/dev/null && echo "✅ ARM64 latest exists" || echo "❌ ARM64 latest missing"
+          docker manifest inspect "$arm64_image:latest" >/dev/null && echo "[OK] ARM64 latest exists" || echo "[FAIL] ARM64 latest missing"
 
           # Get digests for specific platforms
           echo "Getting platform-specific digests..."
@@ -543,9 +615,9 @@ jobs:
           docker manifest push "$universal_image:latest"
 
           # Create version-specific manifests if available
-          if [[ "${{ needs.publish_image.outputs.has-version-tags }}" == "true" ]]; then
-            major_tag="${{ needs.publish_image.outputs.major-tag }}"
-            minor_tag="${{ needs.publish_image.outputs.minor-tag }}"
+          if [[ "$CTX_HAS_VERSION_TAGS" == "true" ]]; then
+            major_tag="$CTX_MAJOR_TAG"
+            minor_tag="$CTX_MINOR_TAG"
 
             if [[ -n "$major_tag" ]]; then
               echo "Creating manifest for $universal_image:$major_tag"
@@ -578,13 +650,20 @@ jobs:
             fi
           fi
 
-          echo "✅ Multi-arch manifests created successfully"
+          echo "[OK] Multi-arch manifests created successfully"
 
       - name: Verify multi-arch manifests
+        env:
+          CTX_IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
+          CTX_VERSION: ${{ needs.publish_image.outputs.version }}
+          CTX_REPOSITORY: ${{ github.repository }}
+          CTX_HAS_VERSION_TAGS: ${{ needs.publish_image.outputs.has-version-tags }}
+          CTX_MAJOR_TAG: ${{ needs.publish_image.outputs.major-tag }}
+          CTX_MINOR_TAG: ${{ needs.publish_image.outputs.minor-tag }}
         run: |
-          image_base_name="${{ needs.generate-matrix.outputs.image-base-name }}"
-          version="${{ needs.publish_image.outputs.version }}"
-          registry="${{ env.REGISTRY }}/${{ github.repository }}"
+          image_base_name="$CTX_IMAGE_BASE_NAME"
+          version="$CTX_VERSION"
+          registry="${{ env.REGISTRY }}/${CTX_REPOSITORY}"
           universal_image="$registry/$image_base_name"
 
           echo "Verifying multi-arch manifests:"
@@ -596,9 +675,9 @@ jobs:
           done
 
           # Verify version tags if they exist
-          if [[ "${{ needs.publish_image.outputs.has-version-tags }}" == "true" ]]; then
-            major_tag="${{ needs.publish_image.outputs.major-tag }}"
-            minor_tag="${{ needs.publish_image.outputs.minor-tag }}"
+          if [[ "$CTX_HAS_VERSION_TAGS" == "true" ]]; then
+            major_tag="$CTX_MAJOR_TAG"
+            minor_tag="$CTX_MINOR_TAG"
 
             for tag in "$major_tag" "$minor_tag"; do
               if [[ -n "$tag" ]]; then

--- a/.github/workflows/workflow-security-scan.yml
+++ b/.github/workflows/workflow-security-scan.yml
@@ -1,0 +1,120 @@
+# .github/workflows/workflow-security-scan.yml
+name: Workflow Security Scan
+
+# Two tracks, because a single scanner version cannot serve both purposes:
+#
+#   gate  - pinned, blocking, runs only when .github/ actually has a diff.
+#           Deterministic, so a red result means "this diff made things worse"
+#           rather than "the scanner learned a new rule overnight". That is what
+#           makes it defensible to block a PR on.
+#
+#   audit - floating (latest), non-blocking, scheduled. A pinned gate stops
+#           discovering new vulnerability classes, so this track exists to catch
+#           what the pin cannot see and raise an issue instead of failing a build.
+#
+# The pin is kept current by Renovate via the annotation below, so "bump
+# deliberately" is enforced by tooling rather than left to memory.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+  schedule:
+    # Mondays 11:00 UTC, an hour after the daily image scan.
+    - cron: '0 11 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: zizmor (pinned gate)
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # upload SARIF to code scanning
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          # renovate: datasource=github-releases depName=zizmorcore/zizmor
+          version: 1.28.0
+          persona: regular
+          min-severity: low
+          inputs: .github/workflows/ .github/actions/
+
+  audit:
+    name: zizmor (latest audit)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # raise a tracking issue when the floating version finds more
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor (latest, non-blocking)
+        id: audit
+        continue-on-error: true
+        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        with:
+          version: latest
+          persona: regular
+          min-severity: low
+          advanced-security: false # gate owns the code-scanning upload
+          inputs: .github/workflows/ .github/actions/
+
+      - name: Raise tracking issue on new findings
+        if: steps.audit.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="zizmor: latest version reports findings the pinned gate does not"
+          existing=$(gh issue list --repo "$REPO" --state open \
+            --label workflow-security --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --repo "$REPO" \
+              --body "Still reproducing on the scheduled audit: $RUN_URL"
+            exit 0
+          fi
+          gh label create workflow-security --repo "$REPO" \
+            --description "Findings from the scheduled zizmor audit" \
+            --color BFD4F2 2>/dev/null || true
+          gh issue create --repo "$REPO" --title "$title" --label workflow-security \
+            --body "The scheduled zizmor audit runs the latest release, while the PR
+          gate runs a pinned version. Latest found something the pin did not.
+
+          Run: $RUN_URL
+
+          Either bump the pinned \`version:\` in
+          \`.github/workflows/workflow-security-scan.yml\` (Renovate normally does
+          this) and fix the findings, or record why they are not applicable."

--- a/Dockerfile.nodejs-24-base
+++ b/Dockerfile.nodejs-24-base
@@ -1,6 +1,11 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314aca9594ee2328c7e876a8081a6c988b2e AS builder
 
 # Install Node.js, npm and Yarn
+# npm is deliberately NOT pinned to a major. Wolfi tracks npm independently of
+# the Node major, and holding it at 11.x reintroduces the tar and
+# brace-expansion advisories (CVE-2026-59871/3/4/5, CVE-2026-13149/14257) whose
+# only fix is npm >= 12.0.1-r2. The installed version is recorded in
+# /tmp/versions.txt so major drift stays visible to consumers.
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache 'nodejs=~24' yarn npm
 
@@ -18,7 +23,9 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 RUN NODE_VERSION=$(node --version | sed 's/v//') && \
     echo "nodejs_major_tag=$(echo $NODE_VERSION | cut -d'.' -f1)" > /tmp/versions.txt && \
     echo "nodejs_minor_tag=$(echo $NODE_VERSION | cut -d'.' -f1-2)" >> /tmp/versions.txt && \
-    echo "nodejs=$NODE_VERSION" >> /tmp/versions.txt
+    echo "nodejs=$NODE_VERSION" >> /tmp/versions.txt && \
+    echo "npm=$(npm --version)" >> /tmp/versions.txt && \
+    echo "yarn=$(yarn --version)" >> /tmp/versions.txt
 
 RUN cat /tmp/versions.txt
 

--- a/Dockerfile.python-3.13-base
+++ b/Dockerfile.python-3.13-base
@@ -2,7 +2,9 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314
 
 # CVE-2026-3644: requires python-3.13 >= 3.13.12-r7
 # CVE-2026-5450/5928: glibc >= 2.43-r7 (forced via apk upgrade)
-# CVE-2026-6357: temp PyPI pip 26.1+ in user dir; restore "py3.13-pip" when Wolfi bumps
+# pip/poetry/etc are installed from PyPI into the user dir so they can be kept ahead of
+# the distro packages; the Wolfi ensurepip wheel (py3-pip-wheel 26.2-r0) is retained so
+# "python3 -m venv" keeps working.
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache --upgrade python-3.13 uv && \
     ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
@@ -16,6 +18,12 @@ ENV POETRY_HOME=/home/nonroot \
 
 RUN python3 -m ensurepip --user --upgrade && \
     python3 -m pip install --no-cache-dir --upgrade --user -v pip poetry cryptography virtualenv
+
+# Raise pip's own bundled dependencies to their fixed versions:
+# msgpack 1.1.2 -> 1.2.1 (GHSA-6v7p-g79w-8964) and pkg_resources removed
+# (CVE-2025-47273, CVE-2026-59890 - setuptools dropped it in 82.0.0).
+COPY --chown=nonroot:nonroot scripts/harden-pip-vendor.py /tmp/harden-pip-vendor.py
+RUN python3 /tmp/harden-pip-vendor.py && rm -f /tmp/harden-pip-vendor.py
 
 # Poetry sets default max workers to num of cpu-cores + 4, but pip max connection pool
 # is set at 10 and will discard any above that when installing dependencies
@@ -36,9 +44,11 @@ echo "poetry=$(poetry --version 2>&1 | awk -F 'version |\\)' '{print $2}' | sed 
 echo "uv=$(uv --version 2>&1 | awk '{print $2}')" >> /tmp/versions.txt
 
 USER root
-# CVE-2026-6357: drop py3-pip-wheel artifacts (transitive dep) so Trivy reads only user-local pip 26.1+
-RUN apk del libcurl-openssl4 curl && \
-    rm -f /usr/share/python-wheels/pip-*.whl /var/lib/db/sbom/py3-pip-wheel-*.spdx.json
+# CVE-2026-6357 no longer applies: Wolfi's py3-pip-wheel is 26.2-r0, past the 26.1 floor,
+# so the bundled ensurepip wheel and its SBOM record are kept. Deleting them previously
+# broke "python3 -m venv" for every downstream consumer, because ensurepip sources its
+# wheel from /usr/share/python-wheels.
+RUN apk del libcurl-openssl4 curl
 
 USER nonroot
 RUN python3 --version

--- a/Dockerfile.python-3.14-base
+++ b/Dockerfile.python-3.14-base
@@ -1,7 +1,9 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:003627df3c1e1bba0c4116afcddb314aca9594ee2328c7e876a8081a6c988b2e AS builder
 
 # CVE-2026-5450/5928: glibc >= 2.43-r7 (forced via apk upgrade)
-# CVE-2026-6357: temp PyPI pip 26.1+ in user dir; restore "py3.14-pip" when Wolfi bumps
+# pip/poetry/etc are installed from PyPI into the user dir so they can be kept ahead of
+# the distro packages; the Wolfi ensurepip wheel (py3-pip-wheel 26.2-r0) is retained so
+# "python3 -m venv" keeps working.
 RUN apk update && apk upgrade --no-cache && \
     apk add --no-cache --upgrade python-3.14 uv && \
     ln -sf /usr/bin/python3.14 /usr/bin/python3 && \
@@ -15,6 +17,12 @@ ENV POETRY_HOME=/home/nonroot \
 
 RUN python3 -m ensurepip --user --upgrade && \
     python3 -m pip install --no-cache-dir --upgrade --user -v pip poetry cryptography virtualenv
+
+# Raise pip's own bundled dependencies to their fixed versions:
+# msgpack 1.1.2 -> 1.2.1 (GHSA-6v7p-g79w-8964) and pkg_resources removed
+# (CVE-2025-47273, CVE-2026-59890 - setuptools dropped it in 82.0.0).
+COPY --chown=nonroot:nonroot scripts/harden-pip-vendor.py /tmp/harden-pip-vendor.py
+RUN python3 /tmp/harden-pip-vendor.py && rm -f /tmp/harden-pip-vendor.py
 
 # Poetry sets default max workers to num of cpu-cores + 4, but pip max connection pool
 # is set at 10 and will discard any above that when installing dependencies
@@ -35,9 +43,11 @@ echo "poetry=$(poetry --version 2>&1 | awk -F 'version |\\)' '{print $2}' | sed 
 echo "uv=$(uv --version 2>&1 | awk '{print $2}')" >> /tmp/versions.txt
 
 USER root
-# CVE-2026-6357: drop py3-pip-wheel artifacts (transitive dep) so Trivy reads only user-local pip 26.1+
-RUN apk del libcurl-openssl4 curl && \
-    rm -f /usr/share/python-wheels/pip-*.whl /var/lib/db/sbom/py3-pip-wheel-*.spdx.json
+# CVE-2026-6357 no longer applies: Wolfi's py3-pip-wheel is 26.2-r0, past the 26.1 floor,
+# so the bundled ensurepip wheel and its SBOM record are kept. Deleting them previously
+# broke "python3 -m venv" for every downstream consumer, because ensurepip sources its
+# wheel from /usr/share/python-wheels.
+RUN apk del libcurl-openssl4 curl
 
 USER nonroot
 RUN python3 --version

--- a/scripts/harden-pip-vendor.py
+++ b/scripts/harden-pip-vendor.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Raise pip's bundled dependencies to their fixed versions.
+
+pip ships copies of several third-party packages under ``pip/_vendor`` and
+records their provenance in ``pip/_vendor/vendor.txt`` and
+``pip/_vendor/bom.cdx.json``. Scanners parse both files as an inventory of
+installed packages, so pip's bundled copies surface as image vulnerabilities.
+
+Two advisories currently apply, and both are resolved here by changing the
+code that is actually present rather than by suppressing the finding:
+
+  msgpack 1.1.2 -> 1.2.1
+      GHSA-6v7p-g79w-8964. Replaced with the pure-Python sources of the
+      already-installed msgpack, which sits in site-packages at a fixed
+      version as a transitive dependency of poetry via cachecontrol.
+
+  pkg_resources -> removed
+      CVE-2025-47273 (fixed in setuptools 78.1.1) and CVE-2026-59890 (fixed
+      in setuptools 83.0.0). setuptools deleted pkg_resources outright in
+      82.0.0, so there is no release that both ships the module and carries
+      both fixes; upstream's fixed state is removal. pip imports it only
+      from the pkg_resources metadata backend, which cannot be selected on
+      Python 3.14+ and is deprecated on earlier versions
+      (see pip/_internal/metadata/__init__.py::_should_use_importlib_metadata).
+
+The script is deliberately strict: any unexpected layout aborts the build
+rather than silently leaving a vulnerable copy in the image.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import shutil
+import sys
+
+MSGPACK_MIN = (1, 2, 1)
+MSGPACK_MODULES = ("__init__.py", "exceptions.py", "ext.py", "fallback.py")
+
+
+def fail(message: str) -> None:
+    sys.exit(f"harden-pip-vendor: {message}")
+
+
+def find_vendor_dir() -> pathlib.Path:
+    import pip
+
+    vendor = pathlib.Path(pip.__file__).resolve().parent / "_vendor"
+    if not vendor.is_dir():
+        fail(f"expected pip vendor directory at {vendor}")
+    return vendor
+
+
+def find_installed_msgpack() -> pathlib.Path:
+    """Locate the real msgpack install, skipping pip's bundled copy."""
+    import importlib.util
+
+    spec = importlib.util.find_spec("msgpack")
+    if spec is None or not spec.origin:
+        fail("msgpack is not installed; cannot source fixed sources from it")
+    src = pathlib.Path(spec.origin).resolve().parent
+    if "_vendor" in src.parts:
+        fail(f"resolved msgpack to pip's bundled copy at {src}")
+    return src
+
+
+def replace_vendored_msgpack(vendor: pathlib.Path) -> str:
+    import msgpack
+
+    if msgpack.version < MSGPACK_MIN:
+        fail(
+            f"installed msgpack {msgpack.__version__} is below the fixed "
+            f"version {'.'.join(str(p) for p in MSGPACK_MIN)}"
+        )
+
+    src = find_installed_msgpack()
+    dst = vendor / "msgpack"
+    if not dst.is_dir():
+        fail(f"expected bundled msgpack at {dst}")
+
+    for name in MSGPACK_MODULES:
+        origin = src / name
+        if not origin.is_file():
+            fail(f"missing {origin} in the installed msgpack")
+        shutil.copyfile(origin, dst / name)
+
+    # The compiled extension is deliberately not copied: pip's bundled copy
+    # has always run the pure-Python fallback, and a .so would not be
+    # importable under pip's vendored module path.
+    shutil.rmtree(dst / "__pycache__", ignore_errors=True)
+    return msgpack.__version__
+
+
+def remove_vendored_pkg_resources(vendor: pathlib.Path) -> None:
+    target = vendor / "pkg_resources"
+    if not target.is_dir():
+        fail(f"expected bundled pkg_resources at {target}")
+    shutil.rmtree(target)
+
+
+def rewrite_vendor_txt(vendor: pathlib.Path, msgpack_version: str) -> None:
+    path = vendor / "vendor.txt"
+    if not path.is_file():
+        fail(f"expected {path}")
+
+    kept: list[str] = []
+    saw_msgpack = saw_setuptools = False
+    for line in path.read_text().splitlines():
+        name = line.strip().split("==")[0].strip().lower()
+        if name == "msgpack":
+            saw_msgpack = True
+            kept.append(f"msgpack=={msgpack_version}")
+        elif name == "setuptools":
+            saw_setuptools = True
+        else:
+            kept.append(line)
+
+    if not saw_msgpack:
+        fail(f"no msgpack entry found in {path}")
+    if not saw_setuptools:
+        fail(f"no setuptools entry found in {path}")
+    path.write_text("\n".join(kept) + "\n")
+
+
+def rewrite_bom(vendor: pathlib.Path, msgpack_version: str) -> None:
+    path = vendor / "bom.cdx.json"
+    if not path.is_file():
+        # Older pip releases predate the bundled CycloneDX BOM.
+        return
+
+    bom = json.loads(path.read_text())
+    components = bom.get("components")
+    if not isinstance(components, list):
+        fail(f"unexpected structure in {path}: no components list")
+
+    kept = []
+    saw_msgpack = saw_setuptools = False
+    for component in components:
+        name = str(component.get("name", "")).lower()
+        if name == "msgpack":
+            saw_msgpack = True
+            component["version"] = msgpack_version
+            purl = component.get("purl")
+            if isinstance(purl, str) and "@" in purl:
+                component["purl"] = f"{purl.split('@', 1)[0]}@{msgpack_version}"
+            kept.append(component)
+        elif name == "setuptools":
+            saw_setuptools = True
+        else:
+            kept.append(component)
+
+    if not saw_msgpack:
+        fail(f"no msgpack component found in {path}")
+    if not saw_setuptools:
+        fail(f"no setuptools component found in {path}")
+
+    bom["components"] = kept
+    path.write_text(json.dumps(bom, indent=2) + "\n")
+
+
+def verify(vendor: pathlib.Path, msgpack_version: str) -> None:
+    """Confirm the result imports and reports the fixed version."""
+    import subprocess
+
+    checks = [
+        (
+            "bundled msgpack version",
+            "import pip._vendor.msgpack as m; "
+            f"assert m.__version__ == {msgpack_version!r}, m.__version__",
+        ),
+        (
+            "pip cachecontrol serializer",
+            "from pip._vendor.cachecontrol.serialize import Serializer; Serializer()",
+        ),
+        (
+            "pip metadata backend",
+            "from pip._internal.metadata import select_backend; "
+            "assert select_backend().NAME == 'importlib', select_backend().NAME",
+        ),
+        (
+            "bundled pkg_resources gone",
+            "import importlib.util as u; "
+            "assert u.find_spec('pip._vendor.pkg_resources') is None",
+        ),
+    ]
+    for label, snippet in checks:
+        result = subprocess.run(
+            [sys.executable, "-c", snippet], capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            fail(f"verification failed ({label}): {result.stderr.strip()}")
+        print(f"  ok: {label}")
+
+    if (vendor / "pkg_resources").exists():
+        fail("pkg_resources directory still present after removal")
+
+
+def main() -> None:
+    vendor = find_vendor_dir()
+    print(f"harden-pip-vendor: hardening {vendor}")
+
+    msgpack_version = replace_vendored_msgpack(vendor)
+    print(f"  bundled msgpack raised to {msgpack_version}")
+
+    remove_vendored_pkg_resources(vendor)
+    print("  bundled pkg_resources removed (setuptools dropped it in 82.0.0)")
+
+    rewrite_vendor_txt(vendor, msgpack_version)
+    rewrite_bom(vendor, msgpack_version)
+    print("  vendor.txt and bom.cdx.json updated")
+
+    verify(vendor, msgpack_version)
+    print("harden-pip-vendor: done")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/container-structure/nodejs-24-base.yaml
+++ b/tests/container-structure/nodejs-24-base.yaml
@@ -7,10 +7,12 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["v24."]
     
+  # npm is not pinned to a major (see Dockerfile.nodejs-24-base), so assert a
+  # version shape rather than a major that Wolfi moves independently of Node.
   - name: "NPM is available"
     command: "npm"
     args: ["--version"]
-    expectedOutput: ["11."]
+    expectedOutput: ["^[0-9]+\\.[0-9]+\\.[0-9]+"]
     
   - name: "User is nobody"
     command: "id"


### PR DESCRIPTION
Unblocks four release builds that failed on 2026-07-31, and clears the
workflow-security backlog they surfaced.

| Failed run | Image | Cause | Fix |
|---|---|---|---|
| [30660626303](https://github.com/interrzero/base-docker-images/actions/runs/30660626303) | python-3.14 v0.0.31 | Trivy: 3 findings from pip's bundled tree | msgpack 1.1.2 -> 1.2.1, bundled pkg_resources removed |
| [30660624543](https://github.com/interrzero/base-docker-images/actions/runs/30660624543) | python-3.13 v0.0.54 | same | same |
| [30660621698](https://github.com/interrzero/base-docker-images/actions/runs/30660621698) | nodejs-24 v0.0.49 | structure test asserted npm `11.` | assert a version shape; npm stays on 12.x |
| [30660619039](https://github.com/interrzero/base-docker-images/actions/runs/30660619039) | go-1.25 v0.1.51 | GHA cache export `not_found` | `ignore-error=true` on `cache-to` |

## No scanner suppressions

Every finding is resolved in the image itself. There is no `.trivyignore`
entry anywhere in this PR.

Trivy parses `pip/_vendor/vendor.txt` and `pip/_vendor/bom.cdx.json` as an
inventory of installed packages, so pip's bundled copies surface as image
CVEs. `scripts/harden-pip-vendor.py` fixes both:

- **msgpack 1.1.2 -> 1.2.1** (GHSA-6v7p-g79w-8964), sourced from the
  already-installed fixed copy in site-packages.
- **pkg_resources removed** (CVE-2025-47273, CVE-2026-59890). There is no
  version to bump to: setuptools deleted `pkg_resources` in 82.0.0, while
  CVE-2026-59890 is only fixed in 83.0.0. Removal *is* upstream's fixed
  state. Safe here because pip imports it only from the pkg_resources
  metadata backend, which cannot be selected on Python 3.14 and is
  deprecated on 3.13.

The script verifies its own result (bundled version, cachecontrol
serializer, metadata backend, absence of pkg_resources) and fails the
build on any unexpected layout rather than leaving a vulnerable copy.

Checked before writing it: Chainguard has no newer parent package.
`py3.14-pip` and `py3.13-pip` are both at `26.2-r0` with a byte-identical
unpatched vendor tree, and there is no `26.2-r1` on either architecture.

## Two deliberate reversals

**npm is not pinned.** Pinning `npm=~11` to satisfy the stale test
introduced 19 findings including CVE-2026-59873 (CRITICAL) plus tar and
brace-expansion advisories whose only remediation is npm >= 12.0.1-r2.
The test now asserts a version shape, and `npm=`/`yarn=` are recorded in
`/tmp/versions.txt` so major drift stays visible without gating on it.

**`python3 -m venv` was broken in both shipped python images.** The
CVE-2026-6357 workaround deleted `/usr/share/python-wheels/pip-*.whl`,
which ensurepip needs. Wolfi's `py3-pip-wheel` is now `26.2-r0`, past the
26.1 floor, so the workaround is obsolete and is removed. Trivy still
exits 0 with the wheel and its SBOM record restored.

## Workflow hardening: zizmor 63 findings -> 0

- **template-injection** (11 HIGH, 5 MED, 1 LOW, 30 INFO): expressions
  routed through `env:` instead of interpolating into `run:` blocks.
- **excessive-permissions** (7): least-privilege workflow and job blocks.
- **artipacked** (8): `persist-credentials: false`, with tag pushes
  authenticating explicitly via `url.insteadOf`.
- **dangerous-triggers / bot-conditions**: auto-approve moves from
  `pull_request_target` to `pull_request` (verified Renovate opens
  in-repo `renovate/*` branches, never forks, so secrets remain
  available and a fork PR fails closed) and gates on the immutable
  numeric user id rather than a spoofable `github.actor` login.
- **cache-poisoning**: `container-structure-test` is downloaded pinned to
  v1.22.1 and checksum-verified instead of cached. The previous step
  fetched `latest` with no integrity check.
- **superfluous-actions**: the release is created with the runner's `gh`,
  removing a third-party action from the publish path. Idempotent, so a
  re-run updates an existing release rather than failing.

## New: workflow-security-scan.yml

Two tracks, because one scanner version cannot serve both purposes:

- **gate** - pinned, blocking, path-filtered to `.github/**`. A red result
  means this diff made things worse, not that the scanner learned a new
  rule overnight.
- **audit** - floating `latest`, non-blocking, weekly. A pinned gate stops
  discovering new vulnerability classes, so this raises an issue for what
  the pin cannot see.

The pin carries a Renovate annotation so it cannot go stale silently.
This split is not theoretical: validating against zizmor 1.24.1 showed the
template-injection work as complete, and 1.28.0 then found 8 more HIGH.

Also bumps Trivy to 0.72.0 in both the publish gate and the daily scan,
and replaces emoji in workflow output with ASCII tags.

## Verification

All four images rebuilt `--no-cache --pull` on **both** architectures:

```
py313/amd64   TRIVY_EXIT=0     py313/arm64   TRIVY_EXIT=0
py314/amd64   TRIVY_EXIT=0     py314/arm64   TRIVY_EXIT=0
node24/amd64  TRIVY_EXIT=0     node24/arm64  TRIVY_EXIT=0
go125/amd64   TRIVY_EXIT=0     go125/arm64   TRIVY_EXIT=0
```

- container structure tests 7/7 PASS
- `python3 -m venv` + `pip install requests` succeeds on both images
- virtualenv, pip 26.2, poetry 2.4.1, uv 0.12.0 all functional
- bundled msgpack reports 1.2.1; bundled pkg_resources absent
- actionlint clean; `act` dry-runs pass for generate-matrix,
  trigger_builds and scan_and_rebuild
- zizmor 1.28.0: no findings at any severity
- trufflehog, gitleaks, ruff, bandit clean; zero non-ASCII

## Follow-ups filed, not folded in

- checkov CKV_DOCKER_2 (no HEALTHCHECK, all Dockerfiles) - arguably a
  false positive for base images with no long-running entrypoint.
- checkov CKV_GHA_7 (workflow_dispatch inputs) - the inputs are the
  feature in both affected workflows.

## Note for reviewers

`go-1.25` needs a fresh release tag after merge. Its Dockerfile is
unchanged here, so the automatic tag-on-merge will not cover it; the fix
for that build was workflow-only.
