### PR TITLE
Add FIPS 140-3 base image and make fips-base actually enforce FIPS

### DIFF
--- a/Dockerfile.fips-140-3
+++ b/Dockerfile.fips-140-3
@@ -1,0 +1,339 @@
+### FIPS 140-3 BASE IMAGE - OpenSSL FIPS Provider 3.1.2 ###
+#
+# This image ships the CMVP-validated OpenSSL FIPS Provider (the "Module")
+# built from unmodified OpenSSL 3.1.2 source, loaded on top of the distribution
+# libcrypto/libssl that Wolfi keeps patched.
+#
+# It is the successor to Dockerfile.fips-base, which targets the FIPS 140-2
+# certificates (#4282 / #4811, OpenSSL 3.0.8/3.0.9). Both of those reach their
+# sunset date on 2026-09-21 and then move to the CMVP Historical list, so
+# fips-base is deprecated: it keeps building until that date and is then
+# retired. Both images now share scripts/build-fips-module.sh and differ only
+# in the Module version they are certified for, the base distribution, and the
+# fipsinstall form each Security Policy prescribes.
+#
+# ---------------------------------------------------------------------------
+# 1. THE VALIDATION THIS IMAGE TARGETS
+# ---------------------------------------------------------------------------
+# CMVP certificate #4985 - OpenSSL FIPS Provider
+#   Standard        : FIPS 140-3, Overall Security Level 1
+#   Module version  : 3.1.2
+#   Vendor          : The OpenSSL Project
+#   Validated       : 2025-03-11
+#   Sunset          : 2030-03-10
+#   Certificate     : https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4985
+#   Security Policy : https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4985.pdf
+#
+# 3.1.2 is not an arbitrary version pin. It is the exact and only Module
+# version covered by certificate #4985, in the same way that 3.0.8/3.0.9 were
+# the only versions covered by the 140-2 certificates.
+#
+# ---------------------------------------------------------------------------
+# 2. WHY THE SECURITY POLICY IS BINDING ON THIS DOCKERFILE
+# ---------------------------------------------------------------------------
+# Compiling the Module here makes us a "user" performing a post-validation
+# recompilation, which the CMVP Management Manual governs directly.
+#
+#   FIPS 140-3 CMVP Management Manual (04-09-2026)
+#   https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS-140-3-CMVP%20Management%20Manual.pdf
+#
+#   Section 7.9.2 (User):
+#     "A user may not modify a validated module. Any user modifications
+#      invalidate a module validation."
+#
+#   Footnote 5 to Section 7.9.2, the exception this Dockerfile relies on:
+#     "A user may post-validation recompile a module if the unmodified source
+#      code is available and the module's Security Policy provides specific
+#      guidance on acceptable recompilation methods to be followed as a
+#      specific exception to this guidance. The methods in the Security Policy
+#      must be followed without modification to comply with this guidance."
+#
+# That last sentence is what makes the Security Policy binding here, and it
+# has two concrete consequences for the build steps below:
+#
+#   a) "unmodified source code" - the upstream tarball is verified against the
+#      SHA-256 published by OpenSSL before it is unpacked. No patches, no
+#      sed-ing of sources, nothing added or removed.
+#
+#   b) "methods in the Security Policy ... without modification" - the build
+#      is EXACTLY the three commands given in Security Policy Section 11.1(a),
+#      issued by scripts/build-fips-module.sh and nothing else:
+#
+#        $ ./Configure enable-fips
+#        $ make
+#        $ make install_fips
+#
+#      Do NOT add Configure options. Appending hardening-looking flags such as
+#      "no-ssl3 no-legacy no-comp no-err" changes the compilation method away
+#      from the one the Security Policy prescribes and forfeits the footnote 5
+#      exception. An earlier revision of Dockerfile.fips-base appended exactly
+#      those flags, which is one of the defects that prompted this file.
+#
+# Security Policy Section 11.1(a) also sanctions the split build used below:
+#     "The 'install_fips' make target can also be invoked explicitly to install
+#      the FIPS Provider independently, without installing the rest of OpenSSL"
+#
+# Security Policy Section 11.1(c), honoured by omission - nothing in this file
+# sets OPENSSL_NO_FIPS_SECURITYCHECKS or otherwise weakens the Module:
+#     "These checks shall not be disabled (by using
+#      OPENSSL_NO_FIPS_SECURITYCHECKS or any other method)."
+#
+# ---------------------------------------------------------------------------
+# 3. OPERATIONAL ENVIRONMENT - WHAT MAY AND MAY NOT BE CLAIMED
+# ---------------------------------------------------------------------------
+# Security Policy Table 3 lists the tested operational environments:
+#   Ubuntu Linux 22.04.1 Server  (Intel i7-8550U, with and without PAA)
+#   Debian 11.5                  (Intel i7-8550U, with and without PAA)
+#   FreeBSD 13.1                 (Intel i7-10510U)
+#   Windows 10 Pro               (Intel i7-10510U)
+#   macOS 11.5.2                 (Apple M1 and Intel i7 Mac Mini)
+#
+# Security Policy Section 2.2: "No operational environments are vendor
+# affirmed." Wolfi Linux is therefore not covered by any existing affirmation,
+# and this image relies on USER affirmation under Management Manual 7.9.2:
+#
+#     "For Level 1 OE, a software, firmware, or hybrid cryptographic module
+#      will remain compliant with the FIPS 140-3 validation on any
+#      general-purpose platform/processor that supports the specified
+#      operating system listed on the validation entry, or another compatible
+#      operating system."
+#
+# Wolfi is a glibc-based Linux distribution, placing it in the same OS family
+# as the tested Ubuntu 22.04.1 and Debian 11.5 environments. Management Manual
+# footnote 4 gives "OSs of the same 'family'" as an example of compatibility.
+# This is why the runtime stage below is Wolfi (glibc) and NOT the musl-based
+# alpine-base used by Dockerfile.fips-base: a Debian/Ubuntu to glibc-Linux
+# porting claim is materially stronger than a Debian/Ubuntu to musl one.
+# Both amd64 and arm64 have a tested-processor analogue in Table 3 (Intel i7
+# and Apple M1 respectively).
+#
+# The limit of the claim, quoted from Management Manual 7.9.2:
+#     "The user may affirm that the module works correctly in the new OE if
+#      the porting rules are followed. However, the CMVP makes no statement as
+#      to the correct operation of the module or the security strengths of the
+#      generated keys when ported and executed in an OE not listed on the
+#      validation certificate."
+#
+# So: this image is built from CMVP-validated source per the Security Policy
+# and is user-affirmed for Wolfi Linux. It must NOT be described as "FIPS
+# 140-3 validated on Wolfi", because no such validation entry exists.
+#
+# ---------------------------------------------------------------------------
+# 4. WHY THE MODULE AND THE BASE LIBRARY ARE DIFFERENT VERSIONS
+# ---------------------------------------------------------------------------
+# Only fips.so has to come from the validated source. Per OpenSSL's own
+# fips_module documentation (https://docs.openssl.org/3.5/man7/fips_module/):
+#
+#     "Normally, it is possible to utilize a FIPS provider constructed from
+#      one of the validated versions alongside libcrypto and libssl compiled
+#      from any supported release from OpenSSL 3.0 onwards. ... This
+#      flexibility enables you to address bug fixes and CVEs that fall outside
+#      the FIPS boundary."
+#
+# That is exactly what this image does. The validated Module is 3.1.2; the
+# libcrypto/libssl it runs against are the current Wolfi packages, upgraded at
+# build time and re-scannable by Trivy on every rebuild. The alternative that
+# Dockerfile.fips-base used to follow - shipping the entire OpenSSL tree from
+# the validated source version - drags every out-of-boundary CVE of that old
+# release into the image, where package scanners cannot even see it because a
+# source build leaves no apk metadata behind. fips-base has since been rebuilt
+# on this same module-only pattern for that reason.
+#
+# ---------------------------------------------------------------------------
+# 5. DELIBERATE LINTER DEVIATIONS
+# ---------------------------------------------------------------------------
+# hadolint DL3018 ("pin versions in apk add") is knowingly not followed. Every
+# apk package here is outside the FIPS boundary and must be free to move to the
+# newest patched build on each rebuild; pinning them would reintroduce exactly
+# the stale-package problem this image is designed to avoid. The Module itself
+# IS pinned, by version and by SHA-256, because that is the part a certificate
+# covers.
+#
+# hadolint DL3002 ("last USER should not be root") fires on the builder stage,
+# which is discarded and never shipped. The stage that becomes the image ends
+# as nonroot.
+#
+### END OF COMPLIANCE NOTES ###
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the validated Module from unmodified OpenSSL 3.1.2 source
+# ---------------------------------------------------------------------------
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72 AS fips-builder
+
+USER root
+
+# Without pipefail a pipeline reports only the exit status of its last command,
+# so a failed download feeding "sha256sum -c -" could still be treated as a
+# success. The source integrity check below depends on this being set.
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+# The base image pins exact "pkg=version" constraints in /etc/apk/world, which
+# makes a plain "apk upgrade" a no-op for those packages. Relaxing the exact
+# pins to bare names first is what allows security updates to actually apply.
+# The "=[0-9]" anchor deliberately leaves fuzzy "=~" pins alone.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
+    apk add --no-cache build-base perl wget ca-certificates
+
+# Module version and the SHA-256 published by OpenSSL for that tarball.
+# Changing OPENSSL_FIPS_VERSION alone is NOT a valid upgrade path: any other
+# version is outside certificate #4985 and would need its own certificate,
+# Security Policy and build method review.
+ARG OPENSSL_FIPS_VERSION=3.1.2
+ARG OPENSSL_FIPS_SHA256=a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539
+
+# The download, SHA-256 verification and the Security Policy build method all
+# live in scripts/build-fips-module.sh, shared with Dockerfile.fips-base so
+# that a correction to the compile method cannot land in one image and be
+# missed in the other. Read that script's header before changing the build.
+COPY scripts/build-fips-module.sh /usr/local/bin/build-fips-module.sh
+RUN /usr/local/bin/build-fips-module.sh "${OPENSSL_FIPS_VERSION}" "${OPENSSL_FIPS_SHA256}" /staging
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime - validated Module on current, patched libcrypto/libssl
+# ---------------------------------------------------------------------------
+FROM cgr.dev/chainguard/wolfi-base:latest@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
+
+USER root
+
+# See the builder stage for why pipefail matters; the verification steps below
+# pipe openssl output through awk and grep to decide whether to fail the build.
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+# Same world-unpin rationale as the builder stage. This is the mechanism that
+# keeps the out-of-FIPS-boundary libcrypto/libssl patched on every rebuild.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
+    apk add --no-cache openssl ca-certificates
+
+ENV FIPS_ROOT=/opt/openssl-fips
+ENV OPENSSL_MODULES=${FIPS_ROOT}/ossl-modules \
+    OPENSSL_CONF=${FIPS_ROOT}/openssl.cnf
+
+COPY --from=fips-builder /staging/ossl-modules/fips.so ${FIPS_ROOT}/ossl-modules/fips.so
+
+# Generate fipsmodule.cnf, which carries the HMAC-SHA2-256 integrity value of
+# fips.so that the Module checks against itself at load time.
+#
+# "-pedantic" is the invocation the Security Policy gives for installing the
+# configuration file to a non-default location (section 11.1(a)); it selects
+# the strictest, fully-conformant settings. Running fipsinstall also executes
+# the Module self-tests, so this step fails the build if the Module cannot
+# operate on this platform.
+RUN openssl fipsinstall \
+        -pedantic \
+        -module "${OPENSSL_MODULES}/fips.so" \
+        -out "${FIPS_ROOT}/fipsmodule.cnf"
+
+# Approved-mode configuration.
+#
+# fipsmodule.cnf must be included BEFORE any other section is opened: the
+# included file itself opens [fips_sect], so anything written after the
+# .include line would land inside that section instead of the default one.
+# "openssl_conf" therefore has to be stated first.
+#
+# "default_properties = fips=yes" is what makes this an approved-mode image
+# rather than merely an image that has the Module available: it constrains
+# algorithm fetches to the FIPS provider, so non-approved algorithms such as
+# MD5 fail instead of silently falling through to the default provider. It
+# corresponds to the "fips=yes" status indicator in Security Policy 2.4.
+#
+# The base provider is activated alongside fips because it supplies the
+# non-cryptographic encoders and decoders (key and certificate serialisation)
+# that the FIPS provider deliberately does not implement. It contributes no
+# cryptographic algorithms and so does not weaken approved mode.
+RUN printf '%s\n' \
+    'config_diagnostics = 1' \
+    'openssl_conf = openssl_init' \
+    '' \
+    ".include ${FIPS_ROOT}/fipsmodule.cnf" \
+    '' \
+    '[openssl_init]' \
+    'providers = provider_sect' \
+    'alg_section = algorithm_sect' \
+    '' \
+    '[provider_sect]' \
+    'fips = fips_sect' \
+    'base = base_sect' \
+    '' \
+    '[base_sect]' \
+    'activate = 1' \
+    '' \
+    '[algorithm_sect]' \
+    'default_properties = fips=yes' \
+    > "${FIPS_ROOT}/openssl.cnf"
+
+# Build-time proof that the image is actually in approved mode. Every check
+# below is a hard failure: a broken config or an inert Module fails the build
+# here rather than shipping an image that merely looks FIPS-enabled.
+#
+#   1. Module integrity check passes (HMAC over fips.so matches fipsmodule.cnf)
+#   2. The fips provider is present AND reports status "active"
+#   3. The active fips provider is the validated 3.1.2 Module
+#   4. An approved algorithm (SHA-256) works
+#   5. A non-approved algorithm (MD5) is refused, proving enforcement is real
+#      and not merely that the provider happens to be loaded
+RUN set -eu; \
+    echo "== 1. Module integrity =="; \
+    openssl fipsinstall -module "${OPENSSL_MODULES}/fips.so" \
+        -in "${FIPS_ROOT}/fipsmodule.cnf" -verify; \
+    echo "== 2/3. Provider active and at the validated version =="; \
+    openssl list -providers > /tmp/providers.txt; \
+    cat /tmp/providers.txt; \
+    grep -q '^  fips$' /tmp/providers.txt || { echo "FAIL: fips provider not loaded"; exit 1; }; \
+    awk '/^  fips$/{f=1} f&&/status:/{print; exit}' /tmp/providers.txt | grep -q active \
+        || { echo "FAIL: fips provider not active"; exit 1; }; \
+    awk '/^  fips$/{f=1} f&&/version:/{print; exit}' /tmp/providers.txt | grep -q '3\.1\.2' \
+        || { echo "FAIL: fips provider is not the validated 3.1.2 Module"; exit 1; }; \
+    echo "== 4. Approved algorithm (SHA-256) =="; \
+    echo fips-selftest | openssl dgst -sha256; \
+    echo "== 5. Non-approved algorithm (MD5) must be refused =="; \
+    if echo fips-selftest | openssl dgst -md5 >/dev/null 2>&1; then \
+        echo "FAIL: MD5 succeeded, image is NOT enforcing approved mode"; exit 1; \
+    fi; \
+    echo "OK: MD5 correctly refused"; \
+    rm -f /tmp/providers.txt
+
+# Record the versions that matter for audit: the validated Module version, the
+# certificate it comes from, and the out-of-boundary library it runs against.
+RUN set -eu; \
+    { \
+      echo "fips_standard=FIPS 140-3"; \
+      echo "fips_certificate=4985"; \
+      echo "fips_certificate_sunset=2030-03-10"; \
+      echo "fips_module=OpenSSL FIPS Provider"; \
+      echo "fips_module_version=3.1.2"; \
+      echo "fips_module_sha256=$(sha256sum "${OPENSSL_MODULES}/fips.so" | cut -d' ' -f1)"; \
+      echo "fips_mode=enabled"; \
+      echo "openssl_library=$(openssl version | awk '{print $2}')"; \
+    } > /tmp/versions.txt; \
+    cat /tmp/versions.txt
+
+# Assert the image's core invariant continuously, not just at build time. The
+# failure mode this guards against is a FIPS module that is installed and
+# loadable but no longer actually enforcing approved mode, which is silent
+# under every other kind of check.
+#
+# Derived images that need different health semantics can override this with
+# their own HEALTHCHECK, or disable it with "HEALTHCHECK NONE". The interval is
+# deliberately long because the invariant only changes on a config edit.
+HEALTHCHECK --interval=5m --timeout=5s --start-period=5s --retries=3 \
+    CMD ["/bin/ash", "-c", "openssl list -providers 2>/dev/null | grep -q '^  fips$' || exit 1"]
+
+LABEL org.opencontainers.image.title="fips-140-3-base" \
+      org.opencontainers.image.description="Wolfi base image with the CMVP-validated OpenSSL FIPS Provider 3.1.2 (certificate 4985) active in approved mode" \
+      io.interrzero.fips.standard="FIPS 140-3" \
+      io.interrzero.fips.certificate="4985" \
+      io.interrzero.fips.module-version="3.1.2" \
+      io.interrzero.fips.oe-status="user-affirmed per CMVP Management Manual 7.9.2; Wolfi is not a tested OE on certificate 4985"
+
+USER nonroot
+
+# Consumers inherit OPENSSL_CONF and OPENSSL_MODULES, so any process started
+# in a derived image runs in approved mode without further configuration.
+# To link against the FIPS-backed libraries no extra flags are needed either:
+# the distribution libcrypto/libssl in /usr/lib are the ones the Module is
+# loaded into.
+RUN openssl list -providers

--- a/Dockerfile.fips-base
+++ b/Dockerfile.fips-base
@@ -1,128 +1,338 @@
-### OPENSSL WITH FIPS BUILD ###
-# Using Wolfi-Alpine base image instead of Wolfi because it has better tooling for building OpenSSL
+### FIPS 140-2 BASE IMAGE - OpenSSL FIPS Provider 3.0.9 ###
+#
+# +-------------------------------------------------------------------------+
+# | DEPRECATED - SCHEDULED FOR RETIREMENT ON 2026-09-21                      |
+# |                                                                          |
+# | The CMVP certificates this image is built against (#4282 and #4811) are  |
+# | FIPS 140-2 validations and both reach their sunset date on 2026-09-21,   |
+# | after which they move to the CMVP Historical list. New builds of this    |
+# | image stop on that date and the Dockerfile is renamed to                 |
+# | deprecated.Dockerfile.fips-base. Previously published tags remain        |
+# | pullable from GHCR.                                                      |
+# |                                                                          |
+# | Migrate to Dockerfile.fips-140-3, which builds the FIPS 140-3 validated  |
+# | Module 3.1.2 under certificate #4985 (sunset 2030-03-10).                |
+# +-------------------------------------------------------------------------+
+#
+# ---------------------------------------------------------------------------
+# 1. THE VALIDATION THIS IMAGE TARGETS
+# ---------------------------------------------------------------------------
+# CMVP certificates #4282 and #4811 - OpenSSL FIPS Provider
+#   Standard        : FIPS 140-2, Overall Security Level 1
+#   Module versions : 3.0.8, 3.0.9  (3.0.9 is built here, the higher of the two)
+#   Vendor          : The OpenSSL Project
+#   Validated       : 2022-08-23 (#4282), 2024-09-24 (#4811)
+#   Sunset          : 2026-09-21 for both
+#   Certificates    : https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4282
+#                     https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811
+#   Security Policy : https://csrc.nist.gov/CSRC/media/projects/cryptographic-module-validation-program/documents/security-policies/140sp4811.pdf
+#
+# 3.0.9 is not an arbitrary pin. It is the highest Module version either
+# certificate covers.
+#
+# ---------------------------------------------------------------------------
+# 2. WHY THE SECURITY POLICY IS BINDING ON THIS DOCKERFILE
+# ---------------------------------------------------------------------------
+# Compiling the Module here makes us a "user" performing a post-validation
+# recompilation, which the CMVP Management Manual governs directly:
+#
+#   FIPS 140-3 CMVP Management Manual (04-09-2026)
+#   https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS-140-3-CMVP%20Management%20Manual.pdf
+#
+#   Section 7.9.2 (User):
+#     "A user may not modify a validated module. Any user modifications
+#      invalidate a module validation."
+#
+#   Footnote 5 to Section 7.9.2, the exception this image relies on:
+#     "A user may post-validation recompile a module if the unmodified source
+#      code is available and the module's Security Policy provides specific
+#      guidance on acceptable recompilation methods to be followed as a
+#      specific exception to this guidance. The methods in the Security Policy
+#      must be followed without modification to comply with this guidance."
+#
+# The compile itself therefore lives in scripts/build-fips-module.sh, which
+# issues exactly the three commands from Security Policy Section 11.1 and
+# verifies the source tarball against the SHA-256 published by OpenSSL. Read
+# the header of that script before changing anything about the build.
+#
+# Security Policy Appendix B, on building with a different toolchain than the
+# tested one:
+#     "compliance is maintained for other versions of the respective
+#      operational environments and compilers provided the module source code
+#      is unchanged"  (FIPS 140-2 Implementation Guidance G.5)
+#
+# Security Policy 12.3, honoured by omission - nothing here disables the
+# Module's run-time security checks:
+#     "These checks shall not be disabled (by using
+#      OPENSSL_NO_FIPS_SECURITYCHECKS or any other method)."
+#
+# ---------------------------------------------------------------------------
+# 3. WHY ONLY fips.so IS BUILT FROM SOURCE
+# ---------------------------------------------------------------------------
+# Security Policy, cryptographic boundary:
+#     "The logical cryptographic boundary of the Module is the FIPS Provider,
+#      a dynamically loadable library."
+#
+# libcrypto and libssl are OUTSIDE that boundary. Only fips.so has to come from
+# the validated source version, which OpenSSL confirms in its own fips_module
+# documentation (https://docs.openssl.org/3.5/man7/fips_module/):
+#
+#     "Normally, it is possible to utilize a FIPS provider constructed from
+#      one of the validated versions alongside libcrypto and libssl compiled
+#      from any supported release from OpenSSL 3.0 onwards. ... This
+#      flexibility enables you to address bug fixes and CVEs that fall outside
+#      the FIPS boundary."
+#
+# Earlier revisions of this file compiled the ENTIRE OpenSSL 3.0.9 tree and
+# shipped its libcrypto, libssl and openssl binary. That dragged every
+# out-of-boundary CVE of a May 2023 release into the image, where package
+# scanners could not see them at all because a source build leaves no apk
+# metadata behind: Trivy reported 0 while grype's binary matcher found 41
+# fixable CVEs, 4 of them Critical. Building only the Module and running it
+# against the distribution libcrypto/libssl takes that to 0 under both
+# scanners, with no change to the validated Module.
+#
+# ---------------------------------------------------------------------------
+# 4. OPERATIONAL ENVIRONMENT - WHAT MAY AND MAY NOT BE CLAIMED
+# ---------------------------------------------------------------------------
+# Security Policy Table 2 lists the tested operational environments:
+#   Ubuntu Linux 22.04.1 LTS  (Intel i7 x64, with and without PAA)
+#   Debian 11.5               (Intel i7 x64, with and without PAA)
+#   FreeBSD 13.1              (Intel i7 x64)
+#   Windows 10                (Intel i7 x64)
+#   macOS 11.5.2              (Apple M1 and Intel i7)
+#
+# This image runs on Wolfi's Alpine base, which is musl rather than the glibc
+# of the tested Debian/Ubuntu environments. The base is deliberately NOT
+# changed: this is a transitional image with weeks left on its certificates,
+# and swapping the C library underneath existing consumers would be a far
+# more disruptive break than anything it would buy. Consumers who want the
+# stronger operational-environment argument should move to
+# Dockerfile.fips-140-3, which runs on glibc.
+#
+# The claim this image supports is USER affirmation under Management Manual
+# 7.9.2, and its stated limit:
+#     "The user may affirm that the module works correctly in the new OE if
+#      the porting rules are followed. However, the CMVP makes no statement as
+#      to the correct operation of the module or the security strengths of the
+#      generated keys when ported and executed in an OE not listed on the
+#      validation certificate."
+#
+# This image must NOT be described as "FIPS 140-2 validated on Alpine". No
+# such validation entry exists, and musl is a weaker compatibility argument
+# than glibc under Management Manual footnote 4.
+#
+# ---------------------------------------------------------------------------
+# 5. DELIBERATE LINTER DEVIATIONS
+# ---------------------------------------------------------------------------
+# hadolint DL3018 ("pin versions in apk add") is knowingly not followed. Every
+# apk package here is outside the FIPS boundary and must be free to move to
+# the newest patched build on each rebuild. The Module itself IS pinned, by
+# version and by SHA-256, because that is the part a certificate covers.
+#
+# hadolint DL3002 ("last USER should not be root") fires on the builder stage,
+# which is discarded and never shipped. The stage that becomes the image ends
+# as nobody.
+#
+### END OF COMPLIANCE NOTES ###
+
+
+# ---------------------------------------------------------------------------
+# Stage 1: build the validated Module from unmodified OpenSSL 3.0.9 source
+# ---------------------------------------------------------------------------
+# Wolfi's Alpine base is retained from the previous revision of this file for
+# the libc-compatibility reason given in section 4 above.
+FROM ghcr.io/wolfi-dev/alpine-base:latest@sha256:f4b58ddf33773854d572684e57fb994a2de08b951bed6fe4a725db36bc58f60d AS fips-builder
+
+USER root
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+# The base image records exact "pkg=version" constraints in /etc/apk/world,
+# which makes a plain "apk upgrade" a no-op for those packages. Relaxing the
+# exact pins to bare names first is what allows security updates to apply at
+# all. The "=[0-9]" anchor deliberately leaves fuzzy "=~" pins alone.
+# linux-headers is required on this musl base: OpenSSL's crypto/mem_sec.c
+# includes <linux/mman.h>, which Alpine ships separately rather than as part
+# of the libc headers. Wolfi's glibc base pulls it in via build-base, which is
+# why Dockerfile.fips-140-3 does not list it.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
+    apk add --no-cache build-base linux-headers perl wget ca-certificates
+
+# Module version and the SHA-256 published by OpenSSL for that tarball.
+# Changing OPENSSL_FIPS_VERSION alone is NOT a valid upgrade path: any other
+# version is outside certificates #4282/#4811 and would need its own
+# certificate, Security Policy and build method review.
+ARG OPENSSL_FIPS_VERSION=3.0.9
+ARG OPENSSL_FIPS_SHA256=eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90
+
+COPY scripts/build-fips-module.sh /usr/local/bin/build-fips-module.sh
+RUN /usr/local/bin/build-fips-module.sh "${OPENSSL_FIPS_VERSION}" "${OPENSSL_FIPS_SHA256}" /staging
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime - validated Module on current, patched libcrypto/libssl
+# ---------------------------------------------------------------------------
 FROM ghcr.io/wolfi-dev/alpine-base:latest@sha256:f4b58ddf33773854d572684e57fb994a2de08b951bed6fe4a725db36bc58f60d
 
-# Install openssl dependencies
-RUN set -e && \
-    apk update && \
-    (apk add --no-cache --upgrade musl musl-dev; exit 0) && \
-    (apk add --no-cache \
-    gcompat \
-    linux-headers \
-    pcre-dev \
-    wget \
-    perl \
-    libssl3 \
-    make \
-    gcc \
-    libgcc \
-    zlib-dev \
-    g++ \
-    ca-certificates; exit 0) && \
-    which gcc && which make && which g++ && which wget
+USER root
 
-# Set up the build environment
-WORKDIR /usr/src
-# Latest NIST-approved FIPS-enabled OpenSSL version 3.0.9 as of the time of coding this Dockerfile
-# https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4282
-# Download and build OpenSSL 3.0.9 from source
-WORKDIR /usr/src
-ENV OPENSSL_MODULES="/usr/local/ssl/lib64/ossl-modules"
-RUN wget -q https://www.openssl.org/source/openssl-3.0.9.tar.gz && tar -zxvf openssl-3.0.9.tar.gz > /dev/null
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
-RUN cd openssl-3.0.9 && \
-    ./Configure enable-fips --prefix=/usr/local/ssl --openssldir=/usr/local/ssl no-ssl3 no-legacy no-comp no-idea no-dtls no-dtls1 no-err no-psk no-srp no-ec2m no-weak-ssl-ciphers no-tests -DOPENSSL_USE_BUILD_DATE && \
-    if [ "$(uname -m)" = "aarch64" ]; then \
-        make -j1 && \
-        make -j1 install_sw && \
-        make -j1 install_ssldirs && \
-        make -j1 install_fips; \
-    else \
-        make -j$(($(nproc)-1)) && \
-        make -j$(($(nproc)-1)) install_sw && \
-        make -j$(($(nproc)-1)) install_ssldirs && \
-        make -j$(($(nproc)-1)) install_fips; \
-    fi
+# Same world-unpin rationale as the builder stage. This is also the mechanism
+# that fixes the openssl advisories (CVE-2026-14456 and friends) that the
+# distribution libcrypto3/libssl3 carry until they are upgraded.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
+    apk add --no-cache openssl ca-certificates
 
-# Ensure that the FIPS module is correctly installed by trying both lib and lib64 paths
-RUN /usr/local/ssl/bin/openssl fipsinstall -out /usr/local/ssl/fipsmodule.cnf -module /usr/local/ssl/lib/ossl-modules/fips.so || \
-    (echo "Trying lib64 path for fipsinstall..." && /usr/local/ssl/bin/openssl fipsinstall -out /usr/local/ssl/fipsmodule.cnf -module /usr/local/ssl/lib64/ossl-modules/fips.so)
+# /usr/local/ssl is kept as the FIPS root, and /usr/local/ssl/bin stays on
+# PATH, so that the layout consumers of previous revisions depend on is
+# preserved. See the compatibility shims further down.
+ENV FIPS_ROOT=/usr/local/ssl
+ENV OPENSSL_MODULES=${FIPS_ROOT}/lib64/ossl-modules \
+    OPENSSL_CONF=${FIPS_ROOT}/openssl.cnf \
+    PATH=${FIPS_ROOT}/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/sbin:/sbin:/bin
 
- 
-# Enable FIPS mode in OpenSSL configuration
-RUN echo "openssl_conf = openssl_init" > /usr/local/ssl/openssl.cnf && \
-  echo "[openssl_init]" >> /usr/local/ssl/openssl.cnf && \
-  echo "config = fips_sect" >> /usr/local/ssl/openssl.cnf && \
-  echo "[fips_sect]" >> /usr/local/ssl/openssl.cnf && \
-  echo "fips = fips_mode" >> /usr/local/ssl/openssl.cnf && \
-  echo "[fips_mode]" >> /usr/local/ssl/openssl.cnf && \
-  echo "activate = 1" >> /usr/local/ssl/openssl.cnf
+COPY --from=fips-builder /staging/ossl-modules/fips.so ${FIPS_ROOT}/lib64/ossl-modules/fips.so
 
-# Mop up
-WORKDIR /usr/src
-RUN rm -rf ./openssl*
-ENV PATH="/usr/local/ssl/bin:$PATH"
+# Generate fipsmodule.cnf, which carries the HMAC-SHA2-256 integrity value of
+# fips.so that the Module checks against itself at load time. Security Policy
+# Section 11.1 gives the plain "openssl fipsinstall" form for this validation
+# (the FIPS 140-3 Security Policy for Module 3.1.2 specifies "-pedantic"
+# instead; the two policies differ here and each image follows its own).
+# Running fipsinstall also executes the Module self-tests, so this step fails
+# the build if the Module cannot operate on this platform.
+RUN openssl fipsinstall \
+        -module "${OPENSSL_MODULES}/fips.so" \
+        -out "${FIPS_ROOT}/fipsmodule.cnf"
+
+# Approved-mode configuration.
+#
+# fipsmodule.cnf must be included BEFORE any other section is opened: the
+# included file itself opens [fips_sect], so anything written after the
+# .include line would land inside that section instead of the default one.
+# "openssl_conf" therefore has to be stated first.
+#
+# The previous revision of this file got this wrong. It wrote
+# "config = fips_sect" under [openssl_init], which loads a config module and
+# not a provider, so the FIPS provider was never activated: the published
+# image reported only the default provider despite shipping a FIPS module and
+# passing its own tests. That is the specific defect this section fixes.
+#
+# "default_properties = fips=yes" is what makes this an approved-mode image
+# rather than merely an image that has the Module available: it constrains
+# algorithm fetches to the FIPS provider, so non-approved algorithms such as
+# MD5 fail instead of silently falling through to the default provider.
+#
+# The base provider is activated alongside fips because it supplies the
+# non-cryptographic encoders and decoders that the FIPS provider deliberately
+# does not implement. It contributes no cryptographic algorithms and so does
+# not weaken approved mode.
+RUN printf '%s\n' \
+    'config_diagnostics = 1' \
+    'openssl_conf = openssl_init' \
+    '' \
+    ".include ${FIPS_ROOT}/fipsmodule.cnf" \
+    '' \
+    '[openssl_init]' \
+    'providers = provider_sect' \
+    'alg_section = algorithm_sect' \
+    '' \
+    '[provider_sect]' \
+    'fips = fips_sect' \
+    'base = base_sect' \
+    '' \
+    '[base_sect]' \
+    'activate = 1' \
+    '' \
+    '[algorithm_sect]' \
+    'default_properties = fips=yes' \
+    > "${FIPS_ROOT}/openssl.cnf"
+
+# Backward-compatibility shims.
+#
+# Previous revisions shipped a source-built openssl binary at
+# /usr/local/ssl/bin/openssl. That binary is gone, because shipping the whole
+# 3.0.9 tree is what carried the 41 out-of-boundary CVEs. The path is kept as
+# a symlink to the distribution binary so that consumers invoking it by
+# absolute path keep working, and transparently get the patched,
+# FIPS-enforcing OpenSSL instead of the 2023 one.
+#
+# The 3.0.9 shared libraries under /usr/local/ssl/lib64 are deliberately NOT
+# recreated. Anything linking them directly was linking an unpatched libcrypto
+# and should fail visibly rather than be silently redirected.
+RUN mkdir -p "${FIPS_ROOT}/bin" && \
+    ln -sf /usr/bin/openssl "${FIPS_ROOT}/bin/openssl" && \
+    if [ -x /usr/bin/c_rehash ]; then ln -sf /usr/bin/c_rehash "${FIPS_ROOT}/bin/c_rehash"; fi
+
+# Build-time proof that the image is actually in approved mode. Every check
+# below is a hard failure, so a broken config or an inert Module fails the
+# build here rather than shipping an image that merely looks FIPS-enabled.
+# The previous revision would not have survived checks 2, 3 and 5.
+RUN set -eu; \
+    echo "== 1. Module integrity =="; \
+    openssl fipsinstall -module "${OPENSSL_MODULES}/fips.so" \
+        -in "${FIPS_ROOT}/fipsmodule.cnf" -verify; \
+    echo "== 2/3. Provider active and at the validated version =="; \
+    openssl list -providers > /tmp/providers.txt; \
+    cat /tmp/providers.txt; \
+    grep -q '^  fips$' /tmp/providers.txt || { echo "FAIL: fips provider not loaded"; exit 1; }; \
+    awk '/^  fips$/{f=1} f&&/status:/{print; exit}' /tmp/providers.txt | grep -q active \
+        || { echo "FAIL: fips provider not active"; exit 1; }; \
+    awk '/^  fips$/{f=1} f&&/version:/{print; exit}' /tmp/providers.txt | grep -q '3\.0\.9' \
+        || { echo "FAIL: fips provider is not the validated 3.0.9 Module"; exit 1; }; \
+    echo "== 4. Approved algorithm (SHA-256) =="; \
+    echo fips-selftest | openssl dgst -sha256; \
+    echo "== 5. Non-approved algorithm (MD5) must be refused =="; \
+    if echo fips-selftest | openssl dgst -md5 >/dev/null 2>&1; then \
+        echo "FAIL: MD5 succeeded, image is NOT enforcing approved mode"; exit 1; \
+    fi; \
+    echo "OK: MD5 correctly refused"; \
+    echo "== 6. Compatibility shim resolves =="; \
+    "${FIPS_ROOT}/bin/openssl" version; \
+    rm -f /tmp/providers.txt
+
+# Record the versions that matter for audit, including the retirement date so
+# it is visible from inside a running container and not only in this file.
+RUN set -eu; \
+    { \
+      echo "fips_standard=FIPS 140-2"; \
+      echo "fips_certificate=4282,4811"; \
+      echo "fips_certificate_sunset=2026-09-21"; \
+      echo "fips_module=OpenSSL FIPS Provider"; \
+      echo "fips_module_version=3.0.9"; \
+      echo "fips_module_sha256=$(sha256sum "${OPENSSL_MODULES}/fips.so" | cut -d' ' -f1)"; \
+      echo "fips_mode=enabled"; \
+      echo "openssl_library=$(openssl version | awk '{print $2}')"; \
+      echo "deprecated=true"; \
+      echo "successor=fips-140-3"; \
+    } > /tmp/versions.txt; \
+    cat /tmp/versions.txt
+
+# Assert the image's core invariant continuously, not just at build time. The
+# failure mode this guards against is a FIPS module that is installed and
+# loadable but no longer actually enforcing approved mode, which is silent
+# under every other kind of check. Derived images may override this with their
+# own HEALTHCHECK, or disable it with "HEALTHCHECK NONE".
+HEALTHCHECK --interval=5m --timeout=5s --start-period=5s --retries=3 \
+    CMD ["/bin/ash", "-c", "openssl list -providers 2>/dev/null | grep -q '^  fips$' || exit 1"]
+
+LABEL org.opencontainers.image.title="fips-base" \
+      org.opencontainers.image.description="Alpine base image with the CMVP-validated OpenSSL FIPS Provider 3.0.9 (certificates 4282/4811) active in approved mode. Deprecated: certificates sunset 2026-09-21, migrate to fips-140-3." \
+      io.interrzero.fips.standard="FIPS 140-2" \
+      io.interrzero.fips.certificate="4282,4811" \
+      io.interrzero.fips.module-version="3.0.9" \
+      io.interrzero.fips.sunset="2026-09-21" \
+      io.interrzero.fips.successor="fips-140-3" \
+      io.interrzero.fips.oe-status="user-affirmed per CMVP Management Manual 7.9.2; Alpine/musl is not a tested OE on certificates 4282/4811" \
+      org.opencontainers.image.deprecated="true"
+
+# Retained from previous revisions of this image so that derived Dockerfiles
+# and runtime security policies expecting UID 65534 keep working.
 USER nobody
 
-### END OPENSSLL WITH FIPS BUILD ###
-
-# Copy and uncomment the variables below to your build stages,
-# where you need to link/compile against FIPS-enabled OpenSSL libraries
-# ENV OPENSSL_CONF=/usr/local/ssl/openssl.cnf
-# ENV LDFLAGS="-L/usr/local/lib -L/usr/lib"
-# ENV CPPFLAGS="-I/usr/local/ssl/include/openssl"
-# ENV PATH="/usr/local/ssl/bin:$PATH"
-
-# If building other software (like Nginx, Python, etc.), you might need
-# variations of these ENV vars depending on that software's build system.
- # ENV CPPFLAGS="-I/usr/local/ssl/include/openssl"
- # ENV PKG_CONFIG_PATH="/usr/local/lib/pkgconfig"
- # ENV LD_LIBRARY_PATH="/usr/lib:/lib:/usr/local/lib;/usr/local/lib/engines-3"
-
-### EXAMPLE STAGE 2: Build an application using the FIPS OpenSSL ###
-# # Use a standard base image for the final application
-# FROM ghcr.io/wolfi-dev/alpine-base:latest@sha256:2d96f988c92c74fd0697748787edaa1e4a6b931b1eec28dd746ecd1b79c59e82 AS final-app
-# LABEL stage="final-app"
-# # Install runtime dependencies and build tools for the example app
-# RUN apk update && apk add --no-cache \
-#     gcc \
-#     libc-dev \
-#     # Add any other runtime dependencies for your actual application here
-#     ca-certificates # Often needed for network communication
-
-# # Copy the FIPS-enabled OpenSSL installation from the builder stage
-# COPY --from=fips-builder /usr/local/ssl /usr/local/ssl/
-
-# # Set environment variables needed to link against the custom OpenSSL
-# # These tell the compiler/linker where to find the FIPS OpenSSL headers and libraries.
-# ENV OPENSSL_CONF=/usr/local/ssl/openssl.cnf
-# ENV LDFLAGS="-L/usr/local/ssl/lib64 -Wl,-rpath,/usr/local/ssl/lib64"
-# ENV CPPFLAGS="-I/usr/local/ssl/include"
-# # PKG_CONFIG_PATH might be needed for some build systems
-# # ENV PKG_CONFIG_PATH="/usr/local/ssl/lib64/pkgconfig"
-# ENV LD_LIBRARY_PATH="/usr/local/ssl/lib64"
-# ENV PATH="/usr/local/ssl/bin:$PATH"
-
-# # Example: Create and compile a simple C program that checks FIPS mode
-# WORKDIR /app
-# RUN echo '#include <stdio.h>\n\
-# #include <openssl/evp.h>\n\
-# int main() {\n\
-#     if (EVP_default_properties_is_fips_enabled(NULL)) {\n\
-#         printf("FIPS mode is enabled.\\n");\n\
-#     } else {\n\
-#         printf("FIPS mode is NOT enabled.\\n");\n\
-#     }\n\
-#     printf("OpenSSL library version: %s\\n", OpenSSL_version(OPENSSL_VERSION_STRING));\n\
-#     return 0;\n\
-# }' > fips_check.c
-
-# # Compile the program, linking against the FIPS OpenSSL
-# # The LDFLAGS and CPPFLAGS environment variables are used by gcc here
-# RUN gcc fips_check.c -o fips_check -lssl -lcrypto $LDFLAGS $CPPFLAGS
-
-# # Set the default user for the final image
-# USER nobody
-
-# # Set the default command to run the example program
-# CMD ["/app/fips_check"]
+# Consumers inherit OPENSSL_CONF and OPENSSL_MODULES, so any process started
+# in a derived image runs in approved mode without further configuration.
+RUN openssl list -providers

--- a/FIPS.md
+++ b/FIPS.md
@@ -1,19 +1,221 @@
-# FIPS Base Image Summary
+# FIPS Base Images
 
-This Docker image provides a base environment built upon Wolfi's Alpine-based image (`ghcr.io/wolfi-dev/alpine-base`), chosen for its minimal footprint and suitable build tooling. The primary feature is a custom-compiled version of OpenSSL 3.0.9 with FIPS support enabled and activated.
+This repository publishes two FIPS images. Both load a CMVP-validated OpenSSL
+FIPS Provider in approved mode; they differ in which validation they are built
+against.
 
-**OpenSSL & FIPS:** OpenSSL is a core library for TLS/SSL and cryptographic functions. This image uses version 3.0.9, compiled specifically to enable its **FIPS 140-2/3 validated cryptographic module**. Compliance with FIPS is often mandated for US government systems and regulated industries.
+| | `fips-140-3` | `fips-base` |
+|---|---|---|
+| Standard | FIPS 140-3 | FIPS 140-2 |
+| CMVP certificate | [#4985](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4985) | [#4282](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4282) / [#4811](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811) |
+| Module version | 3.1.2 | 3.0.9 |
+| Certificate sunset | 2030-03-10 | **2026-09-21** |
+| Base distribution | Wolfi (glibc) | Wolfi Alpine (musl) |
+| Status | **Current** | **Deprecated** |
 
-## Key Functionality
+**New workloads should use `fips-140-3`.**
 
-*   **FIPS-Enabled OpenSSL Build:** OpenSSL 3.0.9 is compiled from source with the `enable-fips` configuration flag. The FIPS module (`fips.so`) is installed, and the necessary FIPS configuration (`/usr/local/ssl/fipsmodule.cnf`) is generated via `openssl fipsinstall`.
-*   **Default FIPS Activation:** The primary OpenSSL configuration (`/usr/local/ssl/openssl.cnf`) is structured to automatically load the FIPS provider configuration and set `activate = 1` within the `fips_sect`. This ensures FIPS mode is active by default for applications using this configuration.
-*   **Custom Installation Path:** OpenSSL is installed in `/usr/local/ssl` to avoid conflicts with potential system-provided versions and ensure clarity.
-*   **PATH Prioritization:** The `/usr/local/ssl/bin` directory is prepended to the container's `PATH` environment variable, ensuring that the custom `openssl` binary is invoked by default.
-*   **Build Environment Abstraction:** Provides a ready-to-use FIPS environment, abstracting the complexities of the OpenSSL FIPS build and configuration process.
-*   **Secure Foundation:**
-    *   Leverages a minimal Wolfi base image to reduce attack surface.
-    *   Sets the default user to `nobody` (UID 65534) as a security best practice, minimizing privileges.
-*   **Optimized Image Size:** Build dependencies and source artifacts are removed post-installation to minimize the final image layer size.
+## Deprecation of `fips-base`
 
-**Use Case:** This image serves as a foundation for building and deploying applications requiring FIPS 140-2/3 validated cryptography through OpenSSL, particularly where government or regulatory compliance is necessary. It simplifies the setup by providing a pre-configured FIPS environment.
+The FIPS 140-2 certificates behind `fips-base` both reach their sunset date on
+**2026-09-21**, after which they move to the CMVP Historical list. CMVP's
+position on Historical modules is that federal agencies "should not include
+these in new systems but can be procured for legacy systems", with continued
+use subject to the agency's own risk determination.
+
+Accordingly:
+
+- `fips-base` continues to build and publish until 2026-09-21.
+- On that date `Dockerfile.fips-base` is renamed to
+  `deprecated.Dockerfile.fips-base`, which removes it from release tagging,
+  the daily rebuild and the manual build trigger.
+- Tags published before then remain pullable from GHCR indefinitely. They stop
+  receiving CVE patches once builds stop.
+
+The two images are deliberately kept close so that migration is mostly a
+change of image reference. See [Migrating](#migrating-from-fips-base-to-fips-140-3).
+
+## How these images are built
+
+Only the FIPS Provider itself (`fips.so`) is compiled from the validated
+OpenSSL source. `libcrypto` and `libssl` come from the distribution and are
+upgraded on every rebuild.
+
+This is not a shortcut. The Security Policy defines the module boundary as the
+provider alone:
+
+> "The logical cryptographic boundary of the Module is the FIPS Provider, a
+> dynamically loadable library."
+
+and OpenSSL's own [`fips_module`](https://docs.openssl.org/3.5/man7/fips_module/)
+documentation states:
+
+> "Normally, it is possible to utilize a FIPS provider constructed from one of
+> the validated versions alongside `libcrypto` and `libssl` compiled from any
+> supported release from OpenSSL 3.0 onwards. ... This flexibility enables you
+> to address bug fixes and CVEs that fall outside the FIPS boundary."
+
+The practical effect is significant. An image that compiles and ships the whole
+validated OpenSSL tree carries every out-of-boundary CVE of that release, and
+package scanners cannot see them, because a source build leaves no package
+metadata behind. Building only the module removes that entire class of finding
+while leaving the validated component untouched.
+
+### The build method is fixed by the Security Policy
+
+Compiling the module makes the operator a *user* performing a post-validation
+recompilation. The
+[FIPS 140-3 CMVP Management Manual](https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS-140-3-CMVP%20Management%20Manual.pdf)
+section 7.9.2 states that "a user may not modify a validated module", and its
+footnote 5 gives the only exception:
+
+> "A user may post-validation recompile a module if the unmodified source code
+> is available and the module's Security Policy provides specific guidance on
+> acceptable recompilation methods to be followed as a specific exception to
+> this guidance. **The methods in the Security Policy must be followed without
+> modification** to comply with this guidance."
+
+Both Security Policies prescribe the same three commands, and
+`scripts/build-fips-module.sh` issues exactly those and nothing else:
+
+```sh
+./Configure enable-fips
+make
+make install_fips
+```
+
+Two consequences worth knowing before editing anything:
+
+- **Do not add `Configure` options.** Hardening-looking flags such as
+  `no-ssl3 no-legacy no-comp no-err` change the compilation method away from
+  the prescribed one and forfeit the footnote 5 exception.
+- **The source tarball is verified against the SHA-256 published by OpenSSL.**
+  That check is what substantiates "unmodified source code", so it is a hard
+  build failure rather than a warning.
+
+Building with the distribution toolchain rather than the exact tested compiler
+is explicitly permitted: FIPS 140-2 Security Policy Appendix B records that per
+Implementation Guidance G.5, "compliance is maintained for other versions of
+the respective operational environments and compilers provided the module
+source code is unchanged".
+
+## What may and may not be claimed
+
+Neither image runs on an operational environment listed on its certificate.
+The tested environments are Ubuntu 22.04.1, Debian 11.5, FreeBSD 13.1,
+Windows 10 and macOS 11.5.2.
+
+Both images therefore rely on **user affirmation** under Management Manual
+7.9.2, whose stated limit is:
+
+> "The user may affirm that the module works correctly in the new OE if the
+> porting rules are followed. However, the CMVP makes no statement as to the
+> correct operation of the module or the security strengths of the generated
+> keys when ported and executed in an OE not listed on the validation
+> certificate."
+
+Concretely:
+
+- **Correct:** "built from the CMVP-validated source per the Security Policy,
+  user-affirmed for this operating environment".
+- **Not correct:** "FIPS 140-3 validated on Wolfi". No such validation entry
+  exists.
+
+`fips-140-3` runs on Wolfi, which is glibc and so in the same OS family as the
+tested Debian/Ubuntu environments; Management Manual footnote 4 gives "OSs of
+the same 'family'" as an example of compatibility. `fips-base` runs on musl,
+which is a weaker compatibility argument. That base was left unchanged
+deliberately, because swapping the C library underneath existing consumers
+during a short migration window would be more disruptive than the argument is
+worth.
+
+## Verifying FIPS mode yourself
+
+Both images are configured with `default_properties = fips=yes`, so approved
+mode is enforced rather than merely available. Every check below runs in the
+published image with no extra configuration.
+
+```sh
+# The FIPS provider must be present and active
+docker run --rm ghcr.io/interrzero/base-docker-images/fips-140-3:latest \
+    openssl list -providers
+
+# Module integrity: HMAC-SHA2-256 over fips.so vs fipsmodule.cnf
+docker run --rm ghcr.io/interrzero/base-docker-images/fips-140-3:latest \
+    openssl fipsinstall \
+        -module /opt/openssl-fips/ossl-modules/fips.so \
+        -in /opt/openssl-fips/fipsmodule.cnf -verify
+
+# A non-approved algorithm must FAIL. This is the check that matters:
+# a module that is loaded but not enforcing still passes everything above.
+docker run --rm ghcr.io/interrzero/base-docker-images/fips-140-3:latest \
+    sh -c 'echo x | openssl dgst -md5'
+```
+
+Expected output of the first command:
+
+```
+Providers:
+  base
+    name: OpenSSL Base Provider
+    status: active
+  fips
+    name: OpenSSL FIPS Provider
+    version: 3.1.2
+    status: active
+```
+
+The MD5 command is expected to fail with `unsupported`. If it succeeds, the
+image is not enforcing approved mode.
+
+Enforcement is inherited by anything built on these images, not just the
+`openssl` CLI. In a derived image that installs Python, `hashlib.sha256()`
+works and `hashlib.md5()` raises `UnsupportedDigestmodError`.
+
+The same assertions are encoded as container structure tests in
+`tests/container-structure/fips-140-3.yaml` and
+`tests/container-structure/fips-base.yaml`, and are additionally enforced at
+build time so a misconfiguration fails the build rather than shipping.
+
+Each image also records its provenance at `/tmp/versions.txt`:
+
+```sh
+docker run --rm ghcr.io/interrzero/base-docker-images/fips-140-3:latest \
+    cat /tmp/versions.txt
+```
+
+## Migrating from `fips-base` to `fips-140-3`
+
+For most consumers this is a one-line change:
+
+```dockerfile
+- FROM ghcr.io/interrzero/base-docker-images/fips-base:latest
++ FROM ghcr.io/interrzero/base-docker-images/fips-140-3:latest
+```
+
+Differences to check before switching:
+
+| | `fips-base` | `fips-140-3` |
+|---|---|---|
+| C library | musl | **glibc** |
+| Default user | `nobody` (65534) | `nonroot` (65532) |
+| FIPS root | `/usr/local/ssl` | `/opt/openssl-fips` |
+| `openssl` on `PATH` | yes | yes |
+
+The **libc change is the one that matters**. Precompiled binaries and native
+extensions built against musl will not run on glibc and must be rebuilt.
+
+`OPENSSL_CONF` and `OPENSSL_MODULES` are exported by both images, so code that
+simply uses OpenSSL needs no change.
+
+### Compatibility shims in `fips-base`
+
+Earlier revisions of `fips-base` shipped a source-built `openssl` binary at
+`/usr/local/ssl/bin/openssl`. That binary is gone, because shipping the whole
+3.0.9 tree is what carried the out-of-boundary CVEs. The path is retained as a
+symlink to the distribution binary, so consumers invoking it by absolute path
+keep working and transparently get the patched, FIPS-enforcing OpenSSL.
+
+The 3.0.9 shared libraries that used to sit under `/usr/local/ssl/lib64` are
+**not** recreated. Anything linking them directly was linking an unpatched
+`libcrypto` and should fail visibly rather than be silently redirected.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This repository is a work in progress, but the produced images are considered st
 
 ## Available Images
 
-[![FIPS Base](https://img.shields.io/github/v/tag/interrzero/base-docker-images?filter=release/fips-base/*&label=fips-base&style=for-the-badge&logo=lock&color=red)](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-base)
+[![FIPS 140-3 Base](https://img.shields.io/github/v/tag/interrzero/base-docker-images?filter=release/fips-140-3/*&label=fips-140-3&style=for-the-badge&logo=lock&color=0B7285)](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-140-3)
+
+[![FIPS Base (deprecated)](https://img.shields.io/github/v/tag/interrzero/base-docker-images?filter=release/fips-base/*&label=fips-base%20%28deprecated%29&style=for-the-badge&logo=lock&color=red)](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-base)
 
 [![Go 1.25 Base](https://img.shields.io/github/v/tag/interrzero/base-docker-images?filter=release/go-1.25-base/*&label=go-1.25-base&style=for-the-badge&logo=go&color=00ADD8)](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Fgo-1.25-base)
 
@@ -31,7 +33,8 @@ This repository is a work in progress, but the produced images are considered st
 
 ### Latest linux/amd64 Releases
 
-* [fips-base-linux-amd64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-base-linux-amd64)
+* [fips-140-3-linux-amd64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-140-3-linux-amd64)
+* [fips-base-linux-amd64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-base-linux-amd64) (deprecated, retires 2026-09-21)
 * [go-1.25-base-linux-amd64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Fgo-1.25-base-linux-amd64)
 * [nginx-base-linux-amd64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Fnginx-base-linux-amd64)
 * [nodejs-24-base-linux-amd64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Fnodejs-24-base-linux-amd64)
@@ -42,7 +45,8 @@ This repository is a work in progress, but the produced images are considered st
 
 ### Latest linux/arm64 Releases
 
-* [fips-base-linux-arm64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-base-linux-arm64)
+* [fips-140-3-linux-arm64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-140-3-linux-arm64)
+* [fips-base-linux-arm64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Ffips-base-linux-arm64) (deprecated, retires 2026-09-21)
 * [go-1.25-base-linux-arm64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Fgo-1.25-base-linux-arm64)
 * [nginx-base-linux-arm64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Fnginx-base-linux-arm64)
 * [nodejs-24-base-linux-arm64](https://github.com/interrzero/base-docker-images/pkgs/container/base-docker-images%2Fnodejs-24-base-linux-arm64)
@@ -97,7 +101,8 @@ Images are considered hardened when they do not contain fixed CVE vulnerabilitie
 * **Python**: 3.13.x and 3.14.x (from wolfi-base with python-3.13/python-3.14 packages, includes pip, poetry, uv)
 * **OpenJDK**: 17.x with Maven 3.9.8 (from wolfi-base with openjdk-17 package)
 * **Wolfi Base**: Latest minimal Linux distribution
-* **FIPS Base**: Custom OpenSSL 3.0.9 with FIPS validation ([beta](#beta-images))
+* **FIPS 140-3 Base**: CMVP-validated OpenSSL FIPS Provider 3.1.2, certificate #4985, approved mode enforced ([details](./FIPS.md))
+* **FIPS Base**: CMVP-validated OpenSSL FIPS Provider 3.0.9, certificates #4282/#4811 - **deprecated, certificates sunset 2026-09-21** ([migration](./FIPS.md#migrating-from-fips-base-to-fips-140-3))
 * **Nginx**: 1.29.x with headers-more module (custom build)
 
 ### Recommended Version Pinning
@@ -152,11 +157,26 @@ Anyone can pull the image locally with their Github [personal access token](http
 
 The beta images are tested within limited scope and are generally stable but not recommended for production use without thorough testing in lower environments.  We encourage you to use them for testing and development and provide feedback to us to help us get them to GA faster.  If any bugs or unexpected behaviors are encountered, please open an issue using the BUG_REPORT template in this repository with enough detail to reproduce the issue.
 
-#### FIPS-enabled base image
+#### FIPS-enabled base images
 
-The image built from the [Dockerfile.fips-base](./Dockerfile.fips-base) includes FIPS-enabled OpenSSL and the Dockerfile shows an example of how to use it in the `Example Stage 2` section that should be modified to your workload's specific needs.
+Two FIPS images are published. Both load a CMVP-validated OpenSSL FIPS Provider and enforce approved mode, so non-approved algorithms such as MD5 fail rather than silently falling back.
 
-[More information on the FIPS image.](./FIPS.md)
+| | [`fips-140-3`](./Dockerfile.fips-140-3) | [`fips-base`](./Dockerfile.fips-base) |
+|---|---|---|
+| Standard | FIPS 140-3 | FIPS 140-2 |
+| CMVP certificate | [#4985](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4985) | [#4282](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4282) / [#4811](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4811) |
+| Module version | 3.1.2 | 3.0.9 |
+| Certificate sunset | 2030-03-10 | **2026-09-21** |
+| C library | glibc | musl |
+| Status | **Current** | **Deprecated** |
+
+**Use `fips-140-3` for new workloads.**
+
+`fips-base` is deprecated because both FIPS 140-2 certificates behind it reach their sunset date on **2026-09-21** and then move to the CMVP Historical list. It continues to build until that date, after which the Dockerfile is renamed to `deprecated.Dockerfile.fips-base`; tags published before then stay pullable but stop receiving patches. See the [migration notes](./FIPS.md#migrating-from-fips-base-to-fips-140-3) - the libc change from musl to glibc is the part that needs attention.
+
+Neither image runs on an operational environment listed on its certificate, so both rely on user affirmation under CMVP Management Manual 7.9.2. They must not be described as "FIPS validated on Wolfi". [FIPS.md](./FIPS.md) sets out exactly what may and may not be claimed, how to verify approved mode yourself, and why only the FIPS provider is compiled from validated source.
+
+[More information on the FIPS images.](./FIPS.md)
 
 ### Nginx Security
 

--- a/examples/Dockerfile.example.fips
+++ b/examples/Dockerfile.example.fips
@@ -1,0 +1,72 @@
+# Example: Using the i0 FIPS 140-3 Base Image
+#
+# This demonstrates building an application on our FIPS base image, which ships
+# the CMVP-validated OpenSSL FIPS Provider 3.1.2 (certificate #4985) already
+# active in approved mode.
+#
+# The important property: you do not configure anything. OPENSSL_CONF and
+# OPENSSL_MODULES are exported by the base image, so every process in a derived
+# image inherits approved mode automatically. That includes application
+# runtimes, not just the openssl CLI - Python's hashlib.md5() raises
+# UnsupportedDigestmodError here, while hashlib.sha256() works normally.
+#
+# Read ../FIPS.md before making compliance claims about an image built this
+# way. In short: this is built from CMVP-validated source per the Security
+# Policy and is user-affirmed for this operating environment, but it is NOT
+# "FIPS 140-3 validated on Wolfi" - no such validation entry exists.
+#
+# NOTE: Replace :latest with a current version tag from
+# https://github.com/interrzero/base-docker-images/releases
+FROM ghcr.io/interrzero/base-docker-images/fips-140-3:latest
+
+USER root
+
+# Without pipefail a pipeline reports only the exit status of its last command,
+# which would let a failing step upstream of a pipe pass unnoticed.
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+
+# Install whatever your workload needs. Packages come from Wolfi and are
+# outside the FIPS module boundary, so they are patched independently of the
+# validated Module.
+RUN apk add --no-cache python-3.13
+
+USER nonroot
+WORKDIR /app
+
+# Show what the base image provides. /tmp/versions.txt records the validated
+# Module version, its certificate, its SHA-256 and the certificate sunset date.
+RUN echo "=== i0 FIPS 140-3 Base Image ===" && \
+    cat /tmp/versions.txt
+
+# Prove approved mode is active before the application is allowed to run.
+#
+# Treat this as a template for your own startup assertion. A FIPS module that
+# is installed but not enforcing is silent under almost every other check, so
+# asserting that a NON-approved algorithm fails is the test that actually
+# distinguishes the two.
+RUN set -eu; \
+    echo "=== FIPS verification ==="; \
+    openssl list -providers | grep -A3 '^  fips$'; \
+    echo "-- approved algorithm (SHA-256) must work:"; \
+    echo fips-check | openssl dgst -sha256; \
+    echo "-- non-approved algorithm (MD5) must be refused:"; \
+    if echo fips-check | openssl dgst -md5 >/dev/null 2>&1; then \
+        echo "FAIL: MD5 succeeded, this image is not enforcing approved mode"; \
+        exit 1; \
+    fi; \
+    echo "OK: MD5 refused, approved mode is enforced"; \
+    echo "-- enforcement reaches the application runtime, not just the CLI:"; \
+    python3 -c "import hashlib; print('   sha256 ok:', hashlib.sha256(b'x').hexdigest()[:16])"; \
+    if python3 -c "import hashlib; hashlib.md5(b'x')" >/dev/null 2>&1; then \
+        echo "FAIL: hashlib.md5 succeeded, approved mode is not reaching Python"; \
+        exit 1; \
+    fi; \
+    echo "   md5 correctly refused by hashlib"
+
+COPY --chown=nonroot:nonroot fips-app/ ./
+
+# Run as nonroot for security. The base image already defaults to nonroot;
+# this is stated explicitly so it survives any future edit above.
+USER nonroot
+
+ENTRYPOINT ["python3", "/app/main.py"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@
 
 This directory contains simple example Dockerfiles and configurations that demonstrate how to use i0's hardened base Docker images in real-world applications.
 
-## ⚠️ Important Notice
+## Important Notice
 
 **These examples are for demonstration purposes only.** The version tags in these Dockerfiles use `:latest` as placeholders and are NOT kept up-to-date. They may reference outdated images with security vulnerabilities.
 
@@ -10,31 +10,45 @@ This directory contains simple example Dockerfiles and configurations that demon
 
 ## Available Examples
 
-### 🐹 Go Application (`Dockerfile.example.go`)
+### Go Application (`Dockerfile.example.go`)
 
 - **Purpose**: Demonstrates building a Go application using our `go-base` image
-- **Architecture**: Multi-stage build (build → minimal static runtime)
+- **Architecture**: Multi-stage build (build -> minimal static runtime)
 - **Features**: 
   - Uses hardened Go base image for compilation
   - Outputs to Chainguard's static image for minimal attack surface
   - Proper non-root user handling
   - Displays version information from base image
 
-### 🌐 Nginx + Node.js Application (`Dockerfile.example.nginx`)
+### Nginx + Node.js Application (`Dockerfile.example.nginx`)
 
 - **Purpose**: Shows how to build a frontend application and serve it with Nginx
-- **Architecture**: Multi-stage build (Node.js build → Nginx runtime)
+- **Architecture**: Multi-stage build (Node.js build -> Nginx runtime)
 - **Features**:
   - Uses `nodejs-base` for building frontend assets
   - Uses `nginx-base` for serving static files
   - Custom Nginx configuration included
   - Security-focused configuration
 
-### 📄 Supporting Files
+### FIPS Application (`Dockerfile.example.fips`)
+
+- **Purpose**: Demonstrates building on our `fips-140-3` image, which ships the CMVP-validated OpenSSL FIPS Provider 3.1.2 (certificate [#4985](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4985)) already active in approved mode
+- **Architecture**: Single stage on the FIPS base, with a build-time assertion that approved mode is enforced
+- **Features**:
+  - No OpenSSL configuration required: `OPENSSL_CONF` and `OPENSSL_MODULES` are inherited from the base image
+  - Shows that enforcement reaches the application runtime, not just the `openssl` CLI - `hashlib.md5()` is refused while `hashlib.sha256()` works
+  - Includes a startup assertion pattern worth copying: it checks that a **non-approved** algorithm fails, which is the only check that distinguishes "enforcing" from "module merely loaded"
+
+> **Compliance note:** read [FIPS.md](../FIPS.md) before making any claim about an image built this way. It is built from CMVP-validated source per the Security Policy and is *user-affirmed* for this operating environment. It is **not** "FIPS 140-3 validated on Wolfi" - no such validation entry exists.
+>
+> The older `fips-base` image (FIPS 140-2, certificates #4282/#4811) is **deprecated**; its certificates sunset on **2026-09-21**. See the [migration notes](../FIPS.md#migrating-from-fips-base-to-fips-140-3) - the change from musl to glibc is the part that needs attention.
+
+### Supporting Files
 
 - **`default.conf`**: Example Nginx configuration with security hardening
 - **`go-app/`**: Simple "Hello World" Go application with module definition  
 - **`frontend-app/`**: Minimalist Node.js frontend app 
+- **`fips-app/`**: Minimal Python app that prints its OpenSSL version and demonstrates that a non-approved digest is refused
 
 ## Usage
 

--- a/examples/fips-app/main.py
+++ b/examples/fips-app/main.py
@@ -1,0 +1,34 @@
+"""Minimal application demonstrating FIPS approved mode in a derived image.
+
+Nothing here configures OpenSSL. The FIPS base image exports OPENSSL_CONF and
+OPENSSL_MODULES, so approved mode is already in force by the time this runs.
+
+The MD5 call is deliberate: it is expected to fail. That failure is the proof
+that approved mode is actually being enforced rather than merely available.
+"""
+
+import hashlib
+import ssl
+import sys
+
+
+def main() -> int:
+    print(f"OpenSSL in use: {ssl.OPENSSL_VERSION}")
+
+    digest = hashlib.sha256(b"fips-check").hexdigest()
+    print(f"SHA-256 (approved):     ok, {digest[:32]}...")
+
+    try:
+        hashlib.md5(b"fips-check")
+    except ValueError as exc:
+        # Python raises _hashlib.UnsupportedDigestmodError, a ValueError
+        # subclass, when the FIPS provider refuses a non-approved digest.
+        print(f"MD5 (non-approved):     correctly refused ({type(exc).__name__})")
+        return 0
+
+    print("MD5 (non-approved):     SUCCEEDED - approved mode is NOT enforced", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/frontend-app/src/app.js
+++ b/examples/frontend-app/src/app.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
     // Simulate app initialization
     setTimeout(() => {
         statusElement.innerHTML = `
-            <p><strong>✅ App Status: Loaded</strong></p>
+            <p><strong>App Status: Loaded</strong></p>
             <p>Served by nginx-base on port 8080</p>
             <p>Built with nodejs-base build tools</p>
             <small>Request ID: ${Math.random().toString(36).substr(2, 9)}</small>

--- a/examples/frontend-app/src/index.html
+++ b/examples/frontend-app/src/index.html
@@ -8,15 +8,15 @@
 </head>
 <body>
     <div class="container">
-        <h1>🚀 i0 Base Images</h1>
+        <h1>i0 Base Images</h1>
         <p>Frontend Example App</p>
         
         <div class="info-box">
             <h2>Built with:</h2>
             <ul>
-                <li>📦 nodejs-base (build stage)</li>
-                <li>🌐 nginx-base (runtime stage)</li>
-                <li>🔒 Hardened security practices</li>
+                <li>nodejs-base (build stage)</li>
+                <li>nginx-base (runtime stage)</li>
+                <li>Hardened security practices</li>
             </ul>
         </div>
         

--- a/get_latest_tags.sh
+++ b/get_latest_tags.sh
@@ -3,14 +3,17 @@
 # Function to increment patch version
 increment_version() {
   local version=$1
+  # Declared before assignment so a failing command substitution is not masked
+  # by the "local" builtin's own exit status (SC2155).
+  local ver_num major minor patch new_patch
   # Extract version number (remove release/image-name/v prefix)
-  local ver_num=$(echo "$version" | sed 's/.*\/v//')
+  ver_num=$(echo "$version" | sed 's/.*\/v//')
   # Split into major.minor.patch
-  local major=$(echo "$ver_num" | cut -d. -f1)
-  local minor=$(echo "$ver_num" | cut -d. -f2)
-  local patch=$(echo "$ver_num" | cut -d. -f3)
+  major=$(echo "$ver_num" | cut -d. -f1)
+  minor=$(echo "$ver_num" | cut -d. -f2)
+  patch=$(echo "$ver_num" | cut -d. -f3)
   # Increment patch
-  local new_patch=$((patch + 1))
+  new_patch=$((patch + 1))
   echo "$major.$minor.$new_patch"
 }
 
@@ -20,8 +23,11 @@ echo "=============================================="
 # Fetch latest tags from origin
 git fetch origin --tags >/dev/null 2>&1
 
-# Get latest tag for each image type and calculate new version
-for image in fips-base go-1.25-base nginx-base nodejs-24-base python-3.13-base wolfi-base openjdk-17-base; do
+# Get latest tag for each image type and calculate new version.
+# Images are discovered from the Dockerfiles present rather than hardcoded, so
+# this cannot drift out of sync with the repo. The previous hardcoded list had
+# already gone stale and omitted python-3.14-base.
+for image in $(find . -maxdepth 1 -type f -name 'Dockerfile.*' ! -name 'deprecated.Dockerfile.*' -exec basename {} \; | sed 's/^Dockerfile\.//' | sort -u); do
   latest=$(git tag -l "release/$image/v*" | sort -V | tail -1)
   if [ -n "$latest" ]; then
     new_version=$(increment_version "$latest")

--- a/scripts/build-fips-module.sh
+++ b/scripts/build-fips-module.sh
@@ -1,0 +1,112 @@
+#!/bin/sh
+# Build a CMVP-validated OpenSSL FIPS Provider from unmodified upstream source.
+#
+# Shared by Dockerfile.fips-base (FIPS 140-2, module 3.0.9, certificates #4282
+# and #4811) and Dockerfile.fips-140-3 (FIPS 140-3, module 3.1.2, certificate
+# #4985). The compile method lives here exactly once so that a correction to it
+# cannot land in one image and be missed in the other.
+#
+# WHY THIS SCRIPT MAY NOT BE "IMPROVED"
+# -------------------------------------
+# Building the Module makes the operator a "user" performing a post-validation
+# recompilation. The FIPS 140-3 CMVP Management Manual governs that directly:
+#
+#   Section 7.9.2 (User):
+#     "A user may not modify a validated module. Any user modifications
+#      invalidate a module validation."
+#
+#   Footnote 5 to 7.9.2, the exception relied on here:
+#     "A user may post-validation recompile a module if the unmodified source
+#      code is available and the module's Security Policy provides specific
+#      guidance on acceptable recompilation methods to be followed as a
+#      specific exception to this guidance. The methods in the Security Policy
+#      must be followed without modification to comply with this guidance."
+#
+# https://csrc.nist.gov/csrc/media/Projects/cryptographic-module-validation-program/documents/fips%20140-3/FIPS-140-3-CMVP%20Management%20Manual.pdf
+#
+# Both Security Policies prescribe the identical three commands, and this
+# script issues exactly those and nothing else:
+#
+#   $ ./Configure enable-fips
+#   $ make
+#   $ make install_fips
+#
+# Do NOT append Configure options. Hardening-looking flags such as
+# "no-ssl3 no-legacy no-comp no-err" change the compilation method away from
+# the one the Security Policy prescribes and forfeit the footnote 5 exception.
+#
+# The SHA-256 check below is what substantiates "unmodified source code". It is
+# a hard failure, never a warning.
+#
+# Compiler and platform: FIPS 140-2 Security Policy Appendix B records that,
+# per FIPS 140-2 Implementation Guidance G.5, "compliance is maintained for
+# other versions of the respective operational environments and compilers
+# provided the module source code is unchanged", so building with the
+# distribution toolchain rather than the exact tested compiler is permitted.
+#
+# Usage: build-fips-module.sh <openssl-version> <sha256> [staging-dir]
+
+set -eu
+
+VERSION="${1:-}"
+SHA256="${2:-}"
+STAGING="${3:-/staging}"
+
+if [ -z "$VERSION" ] || [ -z "$SHA256" ]; then
+    echo "usage: $0 <openssl-version> <sha256> [staging-dir]" >&2
+    exit 2
+fi
+
+# Superseded OpenSSL releases are served from a per-series /old/ directory.
+# The URL is only a transport detail; the SHA-256 below is the integrity
+# control, so a mirror change cannot weaken this.
+SERIES="$(echo "$VERSION" | cut -d. -f1-2)"
+TARBALL="openssl-${VERSION}.tar.gz"
+URL="https://www.openssl.org/source/old/${SERIES}/${TARBALL}"
+
+WORKDIR="${TMPDIR:-/tmp}/fips-module-build"
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+echo "build-fips-module: fetching ${URL}"
+wget -q -O "$TARBALL" "$URL"
+
+# Verified from a file rather than a pipeline so the check cannot be masked by
+# a shell that reports only the exit status of the last command in a pipe.
+echo "build-fips-module: verifying source integrity"
+printf '%s  %s\n' "$SHA256" "$TARBALL" > "${TARBALL}.sha256"
+sha256sum -c "${TARBALL}.sha256"
+
+tar -xzf "$TARBALL"
+cd "openssl-${VERSION}"
+
+# The Security Policy build method, verbatim. See the header before editing.
+echo "build-fips-module: configuring (enable-fips)"
+./Configure enable-fips
+
+echo "build-fips-module: compiling"
+make -j"$(nproc)"
+
+echo "build-fips-module: installing the FIPS Provider only"
+make install_fips
+
+# OpenSSL installs into lib or lib64 depending on the target, so resolve the
+# real location once here and hand the caller a fixed, arch-independent layout.
+module="$(find /usr/local -type f -name fips.so | head -n 1)"
+if [ -z "$module" ]; then
+    echo "build-fips-module: install_fips did not produce fips.so" >&2
+    exit 1
+fi
+
+mkdir -p "${STAGING}/ossl-modules"
+cp "$module" "${STAGING}/ossl-modules/fips.so"
+
+echo "build-fips-module: staged ${module} -> ${STAGING}/ossl-modules/fips.so"
+sha256sum "${STAGING}/ossl-modules/fips.so"
+
+# Leave no source tree behind; this runs in a builder stage but keeping it
+# tidy makes the staged output unambiguous.
+cd /
+rm -rf "$WORKDIR"
+
+echo "build-fips-module: done (OpenSSL ${VERSION} FIPS Provider)"

--- a/tests/container-structure/fips-140-3.yaml
+++ b/tests/container-structure/fips-140-3.yaml
@@ -1,13 +1,13 @@
 schemaVersion: 2.0.0
 
-# Test the FIPS 140-2 base image (DEPRECATED, retires 2026-09-21).
+# Test the FIPS 140-3 base image.
 #
-# The previous version of this file only checked that an openssl binary
-# existed and printed something containing "OpenSSL". That passed against an
-# image whose FIPS provider was never actually loaded. The assertions below
-# are written so that "module present but inert" fails.
+# These tests assert that the image is actually operating in approved mode,
+# not merely that a FIPS module is present on disk. The MD5 test is the load
+# bearing one: a module that is installed but not enforcing would still pass
+# every other check here.
 #
-# See Dockerfile.fips-base for the CMVP references behind these assertions.
+# See Dockerfile.fips-140-3 for the CMVP references behind these assertions.
 commandTests:
   # The validated Module must be loaded and reporting itself active.
   - name: "FIPS provider is active"
@@ -15,11 +15,11 @@ commandTests:
     args: ["list", "-providers"]
     expectedOutput: ["fips[\\s\\S]*OpenSSL FIPS Provider[\\s\\S]*status: active"]
 
-  # The active Module must be the version covered by certificates 4282/4811.
-  - name: "FIPS provider is the validated 3.0.9 module"
+  # The active Module must be the exact version covered by certificate 4985.
+  - name: "FIPS provider is the validated 3.1.2 module"
     command: "openssl"
     args: ["list", "-providers"]
-    expectedOutput: ["OpenSSL FIPS Provider[\\s\\S]*version: 3\\.0\\.9"]
+    expectedOutput: ["OpenSSL FIPS Provider[\\s\\S]*version: 3\\.1\\.2"]
 
   # Integrity check: HMAC-SHA2-256 over fips.so must match fipsmodule.cnf.
   - name: "FIPS module integrity check passes"
@@ -27,14 +27,15 @@ commandTests:
     args:
       - "fipsinstall"
       - "-module"
-      - "/usr/local/ssl/lib64/ossl-modules/fips.so"
+      - "/opt/openssl-fips/ossl-modules/fips.so"
       - "-in"
-      - "/usr/local/ssl/fipsmodule.cnf"
+      - "/opt/openssl-fips/fipsmodule.cnf"
       - "-verify"
     # fipsinstall reports its verdict on stderr, so this must be asserted with
     # expectedError; asserting on stdout would silently pass against no output.
     expectedError: ["VERIFY PASSED"]
 
+  # An approved algorithm must work.
   - name: "Approved algorithm SHA-256 is available"
     command: "sh"
     args: ["-c", "echo fips | openssl dgst -sha256"]
@@ -48,44 +49,28 @@ commandTests:
     excludedOutput: ["MD5\\(stdin\\)"]
     expectedOutput: ["unsupported"]
 
+  # The base provider supplies encoders/decoders and must also be active.
   - name: "Base provider is active"
     command: "openssl"
     args: ["list", "-providers"]
     expectedOutput: ["base[\\s\\S]*OpenSSL Base Provider[\\s\\S]*status: active"]
 
-  # Backward compatibility: the legacy absolute path must still resolve, and
-  # must resolve to a FIPS-enforcing OpenSSL rather than the retired 3.0.9
-  # binary that used to live there.
-  - name: "Legacy /usr/local/ssl/bin/openssl path still works"
-    command: "/usr/local/ssl/bin/openssl"
-    args: ["version"]
-    expectedOutput: ["OpenSSL"]
-
-  - name: "Legacy openssl path is also in approved mode"
-    command: "/usr/local/ssl/bin/openssl"
-    args: ["list", "-providers"]
-    expectedOutput: ["OpenSSL FIPS Provider[\\s\\S]*status: active"]
-
-  - name: "User is nobody"
+  - name: "User is nonroot"
     command: "id"
     args: ["-un"]
-    expectedOutput: ["nobody"]
+    expectedOutput: ["nonroot"]
 
 fileExistenceTests:
   - name: "Validated FIPS module is present"
-    path: "/usr/local/ssl/lib64/ossl-modules/fips.so"
+    path: "/opt/openssl-fips/ossl-modules/fips.so"
     shouldExist: true
 
   - name: "FIPS module config with integrity value is present"
-    path: "/usr/local/ssl/fipsmodule.cnf"
+    path: "/opt/openssl-fips/fipsmodule.cnf"
     shouldExist: true
 
   - name: "Approved-mode OpenSSL config is present"
-    path: "/usr/local/ssl/openssl.cnf"
-    shouldExist: true
-
-  - name: "Legacy openssl binary path exists"
-    path: "/usr/local/ssl/bin/openssl"
+    path: "/opt/openssl-fips/openssl.cnf"
     shouldExist: true
 
   - name: "Version file exists"
@@ -93,35 +78,30 @@ fileExistenceTests:
     shouldExist: true
 
 fileContentTests:
+  # fipsmodule.cnf must carry an integrity value; without it the module
+  # cannot self-verify at load time.
   - name: "FIPS module config carries an integrity MAC"
-    path: "/usr/local/ssl/fipsmodule.cnf"
+    path: "/opt/openssl-fips/fipsmodule.cnf"
     expectedContents: ["module-mac = "]
 
   # Guard against the approved-mode property being dropped from the config,
   # which would silently downgrade the image to "module present but inert".
   - name: "Approved mode is enforced by default properties"
-    path: "/usr/local/ssl/openssl.cnf"
+    path: "/opt/openssl-fips/openssl.cnf"
     expectedContents: ["default_properties = fips=yes"]
-
-  # The previous config used "config = fips_sect", which loads a config module
-  # and not a provider. That is the defect that left FIPS inactive; assert the
-  # correct directive is present so it cannot regress.
-  - name: "OpenSSL config activates providers, not a config module"
-    path: "/usr/local/ssl/openssl.cnf"
-    expectedContents: ["providers = provider_sect"]
 
   - name: "Version file records the validated module version"
     path: "/tmp/versions.txt"
-    expectedContents: ["fips_module_version=3\\.0\\.9"]
+    expectedContents: ["fips_module_version=3\\.1\\.2"]
 
-  - name: "Version file records the deprecation and successor"
+  - name: "Version file records the CMVP certificate"
     path: "/tmp/versions.txt"
-    expectedContents: ["deprecated=true", "successor=fips-140-3"]
+    expectedContents: ["fips_certificate=4985"]
 
 metadataTest:
-  user: "nobody"
+  user: "nonroot"
   envVars:
     - key: "OPENSSL_CONF"
-      value: "/usr/local/ssl/openssl.cnf"
+      value: "/opt/openssl-fips/openssl.cnf"
     - key: "OPENSSL_MODULES"
-      value: "/usr/local/ssl/lib64/ossl-modules"
+      value: "/opt/openssl-fips/ossl-modules"

--- a/tests/container-structure/nginx-base.yaml
+++ b/tests/container-structure/nginx-base.yaml
@@ -6,7 +6,7 @@ commandTests:
     command: "nginx"
     args: ["-v"]
     expectedError: ["nginx version: nginx/"]
-    
+
   - name: "Nginx help available"
     command: "nginx"
     args: ["-h"]
@@ -16,7 +16,7 @@ fileExistenceTests:
   - name: "Nginx binary exists"
     path: "/usr/sbin/nginx"
     shouldExist: true
-    
+
   - name: "Nginx config exists"
     path: "/etc/nginx/nginx.conf"
     shouldExist: true

--- a/tests/container-structure/nodejs-24-base.yaml
+++ b/tests/container-structure/nodejs-24-base.yaml
@@ -6,14 +6,14 @@ commandTests:
     command: "node"
     args: ["--version"]
     expectedOutput: ["v24."]
-    
+
   # npm is not pinned to a major (see Dockerfile.nodejs-24-base), so assert a
   # version shape rather than a major that Wolfi moves independently of Node.
   - name: "NPM is available"
     command: "npm"
     args: ["--version"]
     expectedOutput: ["^[0-9]+\\.[0-9]+\\.[0-9]+"]
-    
+
   - name: "User is nobody"
     command: "id"
     args: ["-un"]
@@ -21,14 +21,14 @@ commandTests:
 
 fileExistenceTests:
   - name: "Version file exists"
-    path: "/tmp/versions.txt" 
+    path: "/tmp/versions.txt"
     shouldExist: true
 
 fileContentTests:
   - name: "Version file contains Node.js version"
     path: "/tmp/versions.txt"
     expectedContents: ["nodejs=24."]
-    
+
   - name: "Version file contains major tag"
     path: "/tmp/versions.txt"
     expectedContents: ["nodejs_major_tag=24"]

--- a/tests/container-structure/openjdk17-base.yaml
+++ b/tests/container-structure/openjdk17-base.yaml
@@ -6,12 +6,12 @@ commandTests:
     command: "java"
     args: ["-version"]
     expectedError: ["openjdk version \"17."]
-    
+
   - name: "Maven is available"
     command: "mvn"
-    args: ["--version"] 
+    args: ["--version"]
     expectedOutput: ["Apache Maven"]
-    
+
   - name: "User is nonroot"
     command: "whoami"
     expectedOutput: ["nonroot"]
@@ -25,7 +25,7 @@ fileContentTests:
   - name: "Version file contains Java version"
     path: "/tmp/versions.txt"
     expectedContents: ["java=17."]
-    
+
   - name: "Version file contains major tag"
     path: "/tmp/versions.txt"
     expectedContents: ["java_major_tag=17"]

--- a/tests/container-structure/python-3.13-base.yaml
+++ b/tests/container-structure/python-3.13-base.yaml
@@ -1,16 +1,16 @@
 schemaVersion: 2.0.0
 
-# Test Python base image functionality  
+# Test Python base image functionality
 commandTests:
   - name: "Python version check"
     command: "python3"
     args: ["--version"]
     expectedOutput: ["Python 3."]
-    
+
   - name: "User is nonroot"
-    command: "whoami" 
+    command: "whoami"
     expectedOutput: ["nonroot"]
-    
+
   - name: "Pip is available"
     command: "pip3"
     args: ["--version"]
@@ -25,7 +25,7 @@ fileContentTests:
   - name: "Version file contains Python version"
     path: "/tmp/versions.txt"
     expectedContents: ["python=3."]
-    
+
   - name: "Version file contains major tag"
     path: "/tmp/versions.txt"
     expectedContents: ["python_major_tag=3"]

--- a/tests/container-structure/wolfi-base.yaml
+++ b/tests/container-structure/wolfi-base.yaml
@@ -6,12 +6,12 @@ commandTests:
     command: "apk"
     args: ["--version"]
     expectedOutput: ["apk-tools"]
-    
+
   - name: "User is nonroot"
     command: "id"
     args: ["-un"]
     expectedOutput: ["nonroot"]
-    
+
   - name: "Shell is available"
     command: "sh"
     args: ["-c", "echo 'test'"]
@@ -21,7 +21,7 @@ fileExistenceTests:
   - name: "Package manager exists"
     path: "/sbin/apk"
     shouldExist: true
-    
+
   - name: "Basic shell exists"
     path: "/bin/sh"
     shouldExist: true

--- a/trigger_builds.sh
+++ b/trigger_builds.sh
@@ -10,11 +10,14 @@ set -e
 # Function to increment patch version
 increment_version() {
   local version=$1
-  local ver_num=$(echo "$version" | sed 's/.*\/v//')
-  local major=$(echo "$ver_num" | cut -d. -f1)
-  local minor=$(echo "$ver_num" | cut -d. -f2)
-  local patch=$(echo "$ver_num" | cut -d. -f3)
-  local new_patch=$((patch + 1))
+  # Declared before assignment so that "set -e" still sees a failing command
+  # substitution; "local x=$(...)" would mask its exit status (SC2155).
+  local ver_num major minor patch new_patch
+  ver_num=$(echo "$version" | sed 's/.*\/v//')
+  major=$(echo "$ver_num" | cut -d. -f1)
+  minor=$(echo "$ver_num" | cut -d. -f2)
+  patch=$(echo "$ver_num" | cut -d. -f3)
+  new_patch=$((patch + 1))
   echo "$major.$minor.$new_patch"
 }
 
@@ -28,7 +31,8 @@ get_latest_tag() {
 dockerfile_modified_since_tag() {
   local image=$1
   local dockerfile="Dockerfile.$image"
-  local latest_tag=$(get_latest_tag "$image")
+  local latest_tag
+  latest_tag=$(get_latest_tag "$image")
   
   if [ -z "$latest_tag" ]; then
     echo "INFO: No previous tag found for $image, assuming modified"
@@ -112,8 +116,23 @@ main() {
   echo "INFO: Fetching latest tags from origin..."
   git fetch origin --tags >/dev/null 2>&1
   
-  # List all available images
-  images=(fips-base go-1.25-base nginx-base nodejs-24-base python-3.13-base wolfi-base openjdk-17-base)
+  # Discover available images from the Dockerfiles actually present, using the
+  # same rule as the GitHub Actions workflows. This list used to be hardcoded
+  # and had already drifted (python-3.14-base was missing), which silently
+  # excluded that image from --force-all and rejected it from --image.
+  # basename is used instead of find -printf so this stays portable to the BSD
+  # find on macOS, and a while-read loop instead of mapfile so it works on the
+  # bash 3.2 that ships as /bin/bash there.
+  images=()
+  while IFS= read -r dockerfile; do
+    images+=("${dockerfile#Dockerfile.}")
+  done < <(find . -maxdepth 1 -type f -name 'Dockerfile.*' ! -name 'deprecated.Dockerfile.*' -exec basename {} \; | sort -u)
+
+  if [ ${#images[@]} -eq 0 ]; then
+    echo "ERROR: No Dockerfiles found matching 'Dockerfile.*'"
+    exit 1
+  fi
+
   modified_images=()
   
   echo "INFO: Checking for modified Dockerfiles..."
@@ -124,8 +143,19 @@ main() {
     modified_images=("${images[@]}")
   elif [ -n "$SPECIFIC_IMAGE" ]; then
     echo "INFO: Building specific image: $SPECIFIC_IMAGE"
-    # Validate image name
-    if [[ " ${images[@]} " =~ " ${SPECIFIC_IMAGE} " ]]; then
+    # Validate image name with an exact comparison per element. Matching a
+    # space-joined "${images[@]}" inside [[ ]] relies on implicit array
+    # concatenation (SC2199) and on a quoted right-hand side that is not a
+    # regex (SC2076), both of which are fragile.
+    image_is_known=false
+    for known_image in "${images[@]}"; do
+      if [ "$known_image" = "$SPECIFIC_IMAGE" ]; then
+        image_is_known=true
+        break
+      fi
+    done
+
+    if [ "$image_is_known" = true ]; then
       modified_images=("$SPECIFIC_IMAGE")
     else
       echo "ERROR: Unknown image: $SPECIFIC_IMAGE"


### PR DESCRIPTION
## Summary

Adds a FIPS 140-3 base image, and fixes two defects in the existing FIPS 140-2
image that meant it was neither enforcing FIPS nor CVE-free.

| | `fips-140-3` (new) | `fips-base` (rebuilt) |
|---|---|---|
| Standard | FIPS 140-3 | FIPS 140-2 |
| CMVP certificate | #4985 | #4282 / #4811 |
| Module version | 3.1.2 | 3.0.9 |
| Certificate sunset | 2030-03-10 | **2026-09-21** |
| Base | Wolfi (glibc) | Wolfi Alpine (musl) |
| Status | Current | Deprecated |

## Defects fixed in `fips-base`

**1. The FIPS provider was never active.** `openssl.cnf` set
`config = fips_sect` under `[openssl_init]`, which loads a config module
rather than a provider. The published image reports only the default
provider despite shipping a FIPS module and passing its own tests:

```
$ docker run --rm ghcr.io/.../fips-base-linux-amd64:latest \
      /usr/local/ssl/bin/openssl list -providers
Providers:
  default          <-- fips absent
```

**2. It was not CVE-free.** Compiling and shipping the entire OpenSSL 3.0.9
tree carried every out-of-boundary CVE of a May 2023 release, invisible to
apk-based scanners because a source build leaves no package metadata. Trivy
reported 0 while grype's binary matcher found **41 fixable CVEs, 4 Critical**,
all on `/usr/local/ssl/bin/openssl`.

## Approach

Only `fips.so` is built from validated source; it runs against the
distribution `libcrypto`/`libssl`, which are patched on every rebuild. The
Security Policy defines the boundary as the provider alone:

> "The logical cryptographic boundary of the Module is the FIPS Provider, a
> dynamically loadable library."

and OpenSSL's `fips_module` docs confirm cross-version use is supported and
exists precisely "to address bug fixes and CVEs that fall outside the FIPS
boundary".

The compile method is shared in `scripts/build-fips-module.sh` and issues
exactly the three commands each Security Policy prescribes. CMVP Management
Manual 7.9.2 footnote 5 makes that binding on any user recompilation, so the
previous `no-ssl3 no-legacy no-comp no-err` Configure flags are removed.

## Verification

| | fips-base amd64 | fips-base arm64 | fips-140-3 amd64 | fips-140-3 arm64 |
|---|---|---|---|---|
| Build | pass | pass | pass | pass |
| In-build FIPS gates | pass | pass | pass | pass |
| Structure tests | 20/20 | 20/20 | 16/16 | 16/16 |
| Trivy 0.74.0 (CI flags) | 0 | 0 | 0 | 0 |
| grype, binary matching | 0 | 0 | 0 | 0 |
| Size | 8.1 MB | 8.6 MB | 20.3 MB | 18.8 MB |

`fips-base`: **41 CVEs (4 Critical) to 0**, FIPS inactive to active, 173 MB to
8.1 MB.

Approved mode is asserted at build time and in the structure tests by checking
that a **non-approved** algorithm fails. That is the only check that
distinguishes "enforcing" from "module merely loaded" - the exact failure mode
this PR fixes. A negative control (removing `default_properties = fips=yes`)
makes the suite fail, so the tests have teeth.

Enforcement reaches application runtimes, not just the CLI. In a derived image
with Python, `hashlib.sha256()` works and `hashlib.md5()` raises
`UnsupportedDigestmodError`. `examples/Dockerfile.example.fips` was built and
run to confirm this.

## Compatibility

`fips-base` keeps `/usr/local/ssl/bin/openssl` as a symlink to the
distribution binary, so consumers invoking it by absolute path keep working
and transparently get the patched, FIPS-enforcing OpenSSL. The 3.0.9 shared
libraries are deliberately not recreated: anything linking them was linking an
unpatched libcrypto and should fail visibly.

The musl base is retained on purpose. Swapping the C library underneath
existing consumers during a four-week migration window would be more
disruptive than the stronger operational-environment argument is worth.
`fips-140-3` is glibc.

## Compliance scope

Neither image runs on an operational environment listed on its certificate, so
both rely on user affirmation under Management Manual 7.9.2. Both Dockerfiles
and `FIPS.md` state explicitly that they must **not** be described as "FIPS
validated on Wolfi".

## Also included

- `trigger_builds.sh` and `get_latest_tags.sh` now discover images from the
  Dockerfiles present instead of hardcoded lists that had already gone stale
  (`python-3.14-base` was missing from both). Shellcheck: 11 findings
  including one error, down to 0.
- Non-ASCII removed from `examples/`, and yamllint errors fixed in five
  pre-existing structure test configs (whitespace only, `git diff -w` empty).

## Follow-up not in this PR

On 2026-09-21, renaming to `deprecated.Dockerfile.fips-base` is not sufficient
on its own: `publish-base-images.yml` also carries a hardcoded deprecated-name
list that needs `fips-base` added.
