### PR TITLE
Make apk upgrade actually apply, and clear zizmor suppressions

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -31,10 +31,10 @@ runs:
         password: ${{ inputs.password }}
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+      uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       with:
         platforms: all
 

--- a/.github/workflows/auto-approve-renovate.yml
+++ b/.github/workflows/auto-approve-renovate.yml
@@ -12,6 +12,12 @@ on:
       - synchronize
       - reopened
 
+# Re-running on a newer commit supersedes the earlier approval, so cancelling
+# an in-flight run is safe here.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -19,8 +25,8 @@ jobs:
   auto-approve:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: write
+      contents: read        # read the PR head to evaluate the author gate
+      pull-requests: write  # submit the APPROVE review on Renovate PRs
     # Gate on the author's immutable numeric id, not github.actor. actor is
     # whoever triggered the event - a synchronize can be a different account -
     # and a login string can be freed up and re-registered. 29139614 is the

--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -10,6 +10,12 @@ on:
 permissions:
   contents: read
 
+# Never cancel: tag creation is not safe to interrupt part-way, and a cancelled
+# run can leave some images tagged and others not.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   detect_changed_images:
     runs-on: ubuntu-latest
@@ -27,7 +33,7 @@ jobs:
             github.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: "${{ secrets.PAT_TOKEN }}"
           fetch-depth: 0
@@ -101,7 +107,7 @@ jobs:
             github.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: "${{ secrets.PAT_TOKEN }}"
           fetch-depth: 0

--- a/.github/workflows/daily-scan-and-rebuild.yml
+++ b/.github/workflows/daily-scan-and-rebuild.yml
@@ -26,13 +26,24 @@ env:
   REBUILD_COOLDOWN_HOURS: "24"  # 1 day (daily rebuilds for both language and non-language)
   CRITICAL_COOLDOWN_HOURS: "0"  # No cooldown for CRITICAL vulnerabilities
 
+# Least privilege by default: the workflow grants nothing, and the single job
+# below widens only what it needs. Without this the run inherits the
+# repository default token permissions.
+permissions: {}
+
+# Never cancel: an interrupted run can push some rebuild tags and skip others,
+# leaving the cooldown state inconsistent.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   scan_and_rebuild:
     runs-on: ubuntu-latest
     permissions:
       contents: write    # Needed to push new tags
       packages: read     # Needed to pull images and inspect manifests
-      actions: read
+      actions: read      # read prior run metadata when applying the rebuild cooldown
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -40,7 +51,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: "${{ secrets.PAT_TOKEN }}"
           fetch-depth: 0 # Required to list tags

--- a/.github/workflows/manual-build-trigger.yml
+++ b/.github/workflows/manual-build-trigger.yml
@@ -30,6 +30,11 @@ env:
 permissions:
   contents: read
 
+# Never cancel: this pushes release tags, which is not safe to interrupt.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   trigger_builds:
     runs-on: ubuntu-latest
@@ -45,7 +50,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           token: "${{ secrets.PAT_TOKEN }}"
@@ -170,9 +175,11 @@ jobs:
           egress-policy: audit
 
       - name: Wait for workflow completion
+        env:
+          CTX_REPOSITORY: ${{ github.repository }}
         run: |
           echo "[INFO] Triggered image builds will appear shortly in the Actions tab"
-          echo "[INFO] https://github.com/${{ github.repository }}/actions"
+          echo "[INFO] https://github.com/${CTX_REPOSITORY}/actions"
           echo ""
           echo "[INFO] Each release tag triggers a separate workflow run that will:"
           echo "   1. Build Docker images for both linux/amd64 and linux/arm64"

--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -18,6 +18,13 @@ env:
 permissions:
   contents: read
 
+# Never cancel. A publish run builds, signs and pushes images and can take over
+# an hour on the emulated arm64 leg; cancelling it risks a partially pushed tag.
+# The group is per-ref, so different images still publish in parallel.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   generate-matrix:
     runs-on: ubuntu-latest
@@ -36,7 +43,7 @@ jobs:
             github.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0 # Needed for git diff in PRs
           persist-credentials: false
@@ -110,12 +117,12 @@ jobs:
       matrix:
         platform: [linux/amd64, linux/arm64]
     permissions:
-      contents: write
-      packages: write
-      security-events: write
-      actions: read
-      attestations: write
-      id-token: write
+      contents: write        # create the GitHub release for the tag
+      packages: write        # push image layers and tags to GHCR
+      security-events: write # upload Trivy results to code scanning
+      actions: read          # read workflow metadata for the build summary
+      attestations: write    # write the SLSA provenance attestation
+      id-token: write        # OIDC token for keyless cosign signing
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -123,7 +130,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -216,7 +223,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.context.outputs.image-name }}
           tags: |
@@ -233,7 +240,7 @@ jobs:
 
       - name: Build Docker Image for ${{ matrix.platform }}
         id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           pull: true
           file: Dockerfile.${{ needs.generate-matrix.outputs.image-base-name }}
@@ -309,7 +316,9 @@ jobs:
           fi
 
       - name: Run Trivy vulnerability scanner for ${{ matrix.platform }}
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0 (post-incident fixed release)
+        # v0.36.0 is the post-incident fixed release; earlier tags were withdrawn.
+        # The version comment must contain only the version, so that context lives here.
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           scan-type: image
           image-ref: ${{ steps.test_image.outputs.image_ref }}
@@ -324,7 +333,7 @@ jobs:
       - name: Push Docker Image for ${{ matrix.platform }}
         id: push
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           file: Dockerfile.${{ needs.generate-matrix.outputs.image-base-name }}
           platforms: ${{ matrix.platform }}
@@ -354,7 +363,7 @@ jobs:
 
       - name: Generate artifact attestation
         if: github.event_name == 'push' && github.ref_type == 'tag'
-        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.context.outputs.image-name }}
           subject-digest: ${{ steps.push.outputs.digest }}
@@ -371,7 +380,7 @@ jobs:
 
       - name: Upload versions artifact for ${{ matrix.platform }}
         if: steps.extract_versions.outputs.extraction-success == 'true' && github.event_name == 'push' && github.ref_type == 'tag'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: versions-file-${{ steps.context.outputs.platform-suffix }}
           path: ${{ steps.extract_versions.outputs.versions-file }}
@@ -383,8 +392,8 @@ jobs:
     if: "github.event_name == 'push' && github.ref_type == 'tag' && needs.generate-matrix.outputs.is_deprecated != 'true'"
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      actions: read
+      contents: write  # create the GitHub release and upload its assets
+      actions: read    # read the publish job outputs used in the release body
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -395,7 +404,7 @@ jobs:
             github.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -407,7 +416,7 @@ jobs:
           platform: linux/amd64
 
       - name: Download artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           path: artifacts/
@@ -419,11 +428,12 @@ jobs:
           CTX_IMAGE_BASE_NAME: ${{ needs.generate-matrix.outputs.image-base-name }}
           CTX_VERSION_TAG: ${{ needs.publish_image.outputs.version }}
           CTX_REPOSITORY: ${{ github.repository }}
+          CTX_REGISTRY: ${{ env.REGISTRY }}
         run: |
           image_base_name="$CTX_IMAGE_BASE_NAME"
           version_tag="$CTX_VERSION_TAG"
           repo_name="$CTX_REPOSITORY"
-          registry="${{ env.REGISTRY }}"
+          registry="$CTX_REGISTRY"
 
           # Use a temporary file to construct the body
           RELEASE_BODY_FILE="$(mktemp)"
@@ -534,8 +544,8 @@ jobs:
     if: "github.event_name == 'push' && github.ref_type == 'tag' && needs.generate-matrix.outputs.is_deprecated != 'true'"
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      packages: write
+      contents: read   # checkout only; no writes needed for manifest creation
+      packages: write  # push the multi-arch manifest lists to GHCR
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
@@ -547,11 +557,11 @@ jobs:
             pkg-containers.githubusercontent.com:443
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - name: Log in to Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -564,10 +574,11 @@ jobs:
           CTX_HAS_VERSION_TAGS: ${{ needs.publish_image.outputs.has-version-tags }}
           CTX_MAJOR_TAG: ${{ needs.publish_image.outputs.major-tag }}
           CTX_MINOR_TAG: ${{ needs.publish_image.outputs.minor-tag }}
+          CTX_REGISTRY: ${{ env.REGISTRY }}
         run: |
           image_base_name="$CTX_IMAGE_BASE_NAME"
           version="$CTX_VERSION"
-          registry="${{ env.REGISTRY }}/${CTX_REPOSITORY}"
+          registry="${CTX_REGISTRY}/${CTX_REPOSITORY}"
 
           echo "Creating multi-arch manifests for $image_base_name"
 
@@ -666,10 +677,11 @@ jobs:
           CTX_HAS_VERSION_TAGS: ${{ needs.publish_image.outputs.has-version-tags }}
           CTX_MAJOR_TAG: ${{ needs.publish_image.outputs.major-tag }}
           CTX_MINOR_TAG: ${{ needs.publish_image.outputs.minor-tag }}
+          CTX_REGISTRY: ${{ env.REGISTRY }}
         run: |
           image_base_name="$CTX_IMAGE_BASE_NAME"
           version="$CTX_VERSION"
-          registry="${{ env.REGISTRY }}/${CTX_REPOSITORY}"
+          registry="${CTX_REGISTRY}/${CTX_REPOSITORY}"
           universal_image="$registry/$image_base_name"
 
           echo "Verifying multi-arch manifests:"

--- a/.github/workflows/workflow-security-scan.yml
+++ b/.github/workflows/workflow-security-scan.yml
@@ -33,6 +33,11 @@ on:
 permissions:
   contents: read
 
+# Safe to cancel: a newer commit's audit supersedes the previous one.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gate:
     name: zizmor (pinned gate)
@@ -48,7 +53,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
@@ -56,7 +61,7 @@ jobs:
         uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           # renovate: datasource=github-releases depName=zizmorcore/zizmor
-          version: 1.28.0
+          version: 1.29.0
           persona: regular
           min-severity: low
           inputs: .github/workflows/ .github/actions/
@@ -75,7 +80,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 

--- a/Dockerfile.go-1.25-base
+++ b/Dockerfile.go-1.25-base
@@ -1,6 +1,12 @@
 FROM cgr.dev/chainguard/wolfi-base:latest@sha256:a31344ab2cb8618db84f535eec56f76f6178b142cb92cb2e48676cc2dcebea72
 
-RUN apk update && apk upgrade --no-cache && \
+# The base image records exact "pkg=version" constraints in /etc/apk/world, which
+# makes a plain "apk upgrade" a no-op for those packages: the solver honours the
+# pin and leaves them behind. Relaxing the exact pins to bare names first is what
+# allows security updates to actually apply. Verified on apk-tools 2 and 3.
+# The "=[0-9]" anchor deliberately leaves fuzzy "=~" pins (e.g. nodejs=~24) alone.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
     apk add --no-cache go-1.25 bash build-base git
 
 USER nonroot

--- a/Dockerfile.nodejs-24-base
+++ b/Dockerfile.nodejs-24-base
@@ -6,7 +6,13 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:a31344ab2cb8618db84f535eec56f76
 # brace-expansion advisories (CVE-2026-59871/3/4/5, CVE-2026-13149/14257) whose
 # only fix is npm >= 12.0.1-r2. The installed version is recorded in
 # /tmp/versions.txt so major drift stays visible to consumers.
-RUN apk update && apk upgrade --no-cache && \
+# The base image records exact "pkg=version" constraints in /etc/apk/world, which
+# makes a plain "apk upgrade" a no-op for those packages: the solver honours the
+# pin and leaves them behind. Relaxing the exact pins to bare names first is what
+# allows security updates to actually apply. Verified on apk-tools 2 and 3.
+# The "=[0-9]" anchor deliberately leaves fuzzy "=~" pins (e.g. nodejs=~24) alone.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
     apk add --no-cache 'nodejs=~24' yarn npm
 
 # Extract Node.js version and save to file

--- a/Dockerfile.python-3.13-base
+++ b/Dockerfile.python-3.13-base
@@ -5,7 +5,13 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:a31344ab2cb8618db84f535eec56f76
 # pip/poetry/etc are installed from PyPI into the user dir so they can be kept ahead of
 # the distro packages; the Wolfi ensurepip wheel (py3-pip-wheel 26.2-r0) is retained so
 # "python3 -m venv" keeps working.
-RUN apk update && apk upgrade --no-cache && \
+# The base image records exact "pkg=version" constraints in /etc/apk/world, which
+# makes a plain "apk upgrade" a no-op for those packages: the solver honours the
+# pin and leaves them behind. Relaxing the exact pins to bare names first is what
+# allows security updates to actually apply. Verified on apk-tools 2 and 3.
+# The "=[0-9]" anchor deliberately leaves fuzzy "=~" pins (e.g. nodejs=~24) alone.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
     apk add --no-cache --upgrade python-3.13 uv && \
     ln -sf /usr/bin/python3.13 /usr/bin/python3 && \
     ln -sf /usr/bin/python3.13 /usr/bin/python

--- a/Dockerfile.python-3.14-base
+++ b/Dockerfile.python-3.14-base
@@ -4,7 +4,13 @@ FROM cgr.dev/chainguard/wolfi-base:latest@sha256:a31344ab2cb8618db84f535eec56f76
 # pip/poetry/etc are installed from PyPI into the user dir so they can be kept ahead of
 # the distro packages; the Wolfi ensurepip wheel (py3-pip-wheel 26.2-r0) is retained so
 # "python3 -m venv" keeps working.
-RUN apk update && apk upgrade --no-cache && \
+# The base image records exact "pkg=version" constraints in /etc/apk/world, which
+# makes a plain "apk upgrade" a no-op for those packages: the solver honours the
+# pin and leaves them behind. Relaxing the exact pins to bare names first is what
+# allows security updates to actually apply. Verified on apk-tools 2 and 3.
+# The "=[0-9]" anchor deliberately leaves fuzzy "=~" pins (e.g. nodejs=~24) alone.
+RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
+    apk update && apk upgrade --no-cache && \
     apk add --no-cache --upgrade python-3.14 uv && \
     ln -sf /usr/bin/python3.14 /usr/bin/python3 && \
     ln -sf /usr/bin/python3.14 /usr/bin/python


### PR DESCRIPTION
Closes #382.

## 1. `apk upgrade` was a no-op on four images

`go-1.25`, `nodejs-24`, `python-3.13` and `python-3.14` all ran
`apk update && apk upgrade --no-cache`, which upgraded **nothing** the base
image had pinned. `wolfi-base` records exact `pkg=version` constraints in
`/etc/apk/world` and the solver honours them:

```
apk update && apk upgrade --no-cache      -> libcrypto3-3.6.3-r5  (unchanged)
apk update && apk upgrade --no-cache -a   -> libcrypto3-3.6.3-r5  (unchanged)
```

Confirmed on apk-tools 2 (wolfi-base) and apk-tools 3 (alpine-base).

This was visible in production, not theoretical. Images built green earlier
today still carried `libcrypto3/libssl3 3.6.3-r5` with `3.6.4-r0` available.
They passed Trivy only because nothing was outstanding against 3.6.3-r5 yet.
Had a CVE landed, **the daily rebuild could not have cleared it** - which is
precisely how `fips-base` ended up red this morning.

Relaxing exact pins to bare names before upgrading fixes it:

```dockerfile
RUN sed -i -E 's/=[0-9].*$//' /etc/apk/world && \
    apk update && apk upgrade --no-cache && \
```

### Verification

| Image | upgradable before | upgradable after | libcrypto3 | CST | Trivy |
|---|---|---|---|---|---|
| go-1.25-base | 3 | **0** | 3.6.4-r0 | PASS | 0 |
| nodejs-24-base | 3 | **0** | 3.6.4-r0 | PASS | 0 |
| python-3.13-base | 3 | **0** | 3.6.4-r0 | PASS | 0 |
| python-3.14-base | 6 | **0** | 3.6.4-r0 | n/a | 0 |

The `=[0-9]` anchor deliberately preserves fuzzy `=~` pins. Verified the
language majors did not drift: node **24.19.0** (world entry still `nodejs~24`),
python **3.13.15** / **3.14.7**, go **1.25.12**.

python-3.14-base has no structure test config at all - a pre-existing gap of
the same class as the `openjdk17-base.yaml` naming mismatch, tracked separately.

## 2. zizmor (#382)

The scheduled audit reported one `ref-version-mismatch` the pinned gate did
not. Sweeping **every** pin found 8 more the audit had not yet surfaced, all
using a floating major alias as the version comment:

```
docker/setup-buildx-action  # v4  -> # v4.3.0
actions/checkout            # v7  -> # v7.0.1
...
```

Each SHA was resolved through the GitHub API, dereferencing annotated tags, to
confirm the hash genuinely matches the version now named. `trivy-action` was
already correct; its comment only needed the trailing prose moved to its own
line, since the audit requires the comment to contain a version and nothing
else.

The gate moves **1.28.0 -> 1.29.0** so it actually covers the audit that raised
the issue. Without this, the next Renovate bump would have turned a green PR
red.

## 3. Suppressed findings, resolved

`regular` persona hid 35 findings. Reviewed and fixed:

- **template-injection x4** - `env.REGISTRY` and `github.repository` expanded
  inside `run:` blocks. Moved to `env:` indirection, matching the pattern
  already used throughout these workflows. Not attacker-controllable in
  practice, but the fix is free and removes the class.
- **undocumented-permissions x6** - every permission now states why it exists.
- **excessive-permissions x1** - `daily-scan-and-rebuild` had no workflow-level
  `permissions:` block and inherited repository defaults. Now `permissions: {}`,
  with the single job widening only what it needs.
- **concurrency-limits x6** - added concurrency groups. Everything that pushes
  tags, builds or publishes uses **`cancel-in-progress: false`**: a cancelled
  publish can leave a partially pushed tag, and the arm64 leg runs over an hour
  under QEMU. Only auto-approve and the audit cancel, where a newer run
  genuinely supersedes the old.

Result: **zero findings at both `regular` and `pedantic`** (pedantic was 17).

## Left deliberately undone

At the strictest `auditor` persona, 8 `secrets-outside-env` remain. These are
not `env:` problems - zizmor is asking for `PAT_TOKEN` to be scoped to a GitHub
**deployment Environment** with protection rules. That is a repository settings
change affecting 8 jobs and could add approval friction to the daily rebuild,
so it needs a decision rather than a drive-by commit.

`CKV_DOCKER_2` (no HEALTHCHECK) still fails on these four images. Verified
identical before and after this change; a healthcheck on a language base image
with no service is not meaningful. Tracked separately.

## Validation

`act --list` parses all workflows, `actionlint` clean, `yamllint` clean,
`gitleaks` no leaks, non-ASCII zero, checkov unchanged from baseline.
