### PR TITLE
Move three low-egress jobs from harden-runner audit to block

### DIFF
--- a/.github/workflows/manual-build-trigger.yml
+++ b/.github/workflows/manual-build-trigger.yml
@@ -172,7 +172,11 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          egress-policy: audit
+          # This job only echoes text: no checkout, no network, no other actions.
+          # Nothing to allow beyond the runner's own control plane.
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
 
       - name: Wait for workflow completion
         env:

--- a/.github/workflows/workflow-security-scan.yml
+++ b/.github/workflows/workflow-security-scan.yml
@@ -50,7 +50,17 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          egress-policy: audit
+          # Endpoints derived from an observed run, not guessed:
+          #   github.com / objects.githubusercontent.com - checkout and action tarballs
+          #   ghcr.io / pkg-containers.githubusercontent.com - the zizmor container image
+          #   api.github.com - SARIF upload to code scanning, and gh issue create
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -77,7 +87,17 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          egress-policy: audit
+          # Endpoints derived from an observed run, not guessed:
+          #   github.com / objects.githubusercontent.com - checkout and action tarballs
+          #   ghcr.io / pkg-containers.githubusercontent.com - the zizmor container image
+          #   api.github.com - SARIF upload to code scanning, and gh issue create
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            ghcr.io:443
+            github.com:443
+            objects.githubusercontent.com:443
+            pkg-containers.githubusercontent.com:443
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Follow-up to #389. This change was pushed to that PR's branch after the squash
merge had already been computed, so it did not land on main. Recovered here
unchanged.

## What this does

harden-runner is already on all 12 jobs, but half were still `egress-policy:
audit`, which records traffic and enforces only StepSecurity's global
known-compromised blocklist. This flips the three whose egress is small and
knowable, taking the split from **6 block / 6 audit to 9 / 3**.

`wait_for_completion` only echoes text: no checkout, no other actions, no
network of its own. One endpoint.

The two zizmor jobs need more than expected, so their `allowed-endpoints` are
derived from an observed run rather than reasoned from source:

```
github.com, objects.githubusercontent.com      checkout and action tarballs
ghcr.io, pkg-containers.githubusercontent.com  the zizmor container image
api.github.com                                 SARIF upload, gh issue create
```

The container pull is the non-obvious part - `zizmor-action` does not install a
binary, it runs `ghcr.io/zizmorcore/zizmor@sha256:...`, which needs GHCR blob
serving as well as the registry host.

## Validating the allowlist

The zizmor workflow runs on every pull request, so this PR exercises its own
allowlist under `block` before merge. If an endpoint is missing the gate fails
here, names it, and the fix is a one-line addition.

Worth stating plainly: the equivalent gate run on #389 executed in `audit` mode
because it predated this commit, so that PR did **not** validate these
endpoints. This PR is the first real test.

## Left on audit, deliberately

`publish_image`, `scan_and_rebuild` and `trigger_builds`. Their egress spans
container registries, apk repositories, sigstore and the Trivy database, and it
drifts - #389 itself added `www.openssl.org` to what `publish_image` needs for
the FIPS module build. Under `block` with a stale allowlist that is a broken
release pipeline rather than a warning.

Tightening those should be driven by the endpoint data harden-runner has
already recorded in the StepSecurity dashboard, on its own PR with a soak.
