### PR TITLE
Pin cosign, sign in both formats, and verify after signing

### DIFF
--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -347,6 +347,15 @@ jobs:
       - name: Install cosign
         if: github.event_name == 'push' && github.ref_type == 'tag'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the cosign BINARY, not just the action. Left unset, the installer
+          # tracks whatever cosign is current, and a cosign major bump silently
+          # changes the on-registry signature format of every published image.
+          # That is exactly what happened when the default moved to v3: images
+          # kept signing green while cosign v2 clients started reporting
+          # "no signatures found" against them.
+          # renovate: datasource=github-releases depName=sigstore/cosign
+          cosign-release: v3.0.6
 
       - name: Sign container image with cosign
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -358,8 +367,40 @@ jobs:
           for tag in ${TAGS}; do
             images+="${tag}@${DIGEST} "
           done
+          # Sign twice, once per storage format, so consumers on either cosign
+          # major can verify. The two cannot collide: the legacy format writes a
+          # "sha256-<digest>.sig" tag, while the Sigstore bundle format writes
+          # the "sha256-<digest>" referrers-fallback tag.
+          #   --new-bundle-format=false  readable by cosign v2.x and v3.x
+          #   --new-bundle-format=true   the v3 default, invisible to v2.x
           # shellcheck disable=SC2086
-          cosign sign --yes ${images}
+          cosign sign --yes --new-bundle-format=false ${images}
+          # shellcheck disable=SC2086
+          cosign sign --yes --new-bundle-format=true ${images}
+
+      - name: Verify signatures are discoverable in both formats
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          CTX_IMAGE_NAME: ${{ steps.context.outputs.image-name }}
+          CTX_REPOSITORY: ${{ github.repository }}
+          CTX_REGISTRY: ${{ env.REGISTRY }}
+        run: |
+          set -eu
+          ref="${CTX_REGISTRY}/${CTX_REPOSITORY}/${CTX_IMAGE_NAME}@${DIGEST}"
+          # Assert the invariant rather than trust that signing exited 0. This
+          # is what would have caught the silent v2 -> v3 format change: the
+          # sign step stayed green while the published signature became
+          # undiscoverable to half the clients that verify it.
+          for fmt in false true; do
+            echo "== verifying with --new-bundle-format=${fmt}"
+            cosign verify \
+              --new-bundle-format="${fmt}" \
+              --certificate-identity-regexp "https://github.com/${CTX_REPOSITORY}/.github/workflows/.*" \
+              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+              "${ref}" > /dev/null
+          done
+          echo "OK: verifies in both the legacy and Sigstore bundle formats"
 
       - name: Generate artifact attestation
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -488,6 +529,10 @@ jobs:
             --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \\
             ${registry}/${repo_name}/${image_base_name}-linux-arm64:latest
           \`\`\`
+
+          Signed in both cosign storage formats, so any cosign 2.x or 3.x client
+          can verify. To target one explicitly, pass \`--new-bundle-format=false\`
+          for the legacy format or \`=true\` for the Sigstore bundle format.
 
           **Verify with GitHub CLI:**
           \`\`\`bash

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ cosign verify \
   ghcr.io/interrzero/base-docker-images/wolfi-base-linux-amd64:latest
 ```
 
+Images are signed in **both** cosign storage formats, so any cosign 2.x or 3.x
+client can verify them. If you need to target one explicitly, pass
+`--new-bundle-format=false` for the legacy format or `=true` for the Sigstore
+bundle format.
+
+> Signatures published before 2026-08-26 exist only in the Sigstore bundle
+> format and are **not** discoverable by cosign 2.x, which reports
+> `no signatures found` against a correctly signed image. Verify those with
+> cosign 3.x.
+
 **Using GitHub CLI:**
 ```bash
 gh attestation verify oci://ghcr.io/interrzero/base-docker-images/wolfi-base-linux-amd64:latest \


### PR DESCRIPTION
## The actual defect: the cosign binary was never pinned

`sigstore/cosign-installer` is SHA-pinned, but `cosign-release` was unset - so
the installer tracked whatever cosign was current. When the default moved to v3,
the on-registry **signature format of every published image changed** with no
PR, no review and no changelog entry.

Every other tool in this repo is pinned: Trivy `v0.74.0`, zizmor `1.29.0`,
container-structure-test `v1.22.1`, all actions by SHA. cosign was the outlier,
and it is the one that decides whether the supply-chain signatures are
verifiable at all.

## The symptom

cosign 2.x reports `no signatures found` against images that v3 signed
correctly, because v3's Sigstore bundle format is not discoverable by a v2
client. Meanwhile `README.md` and every generated release body tell consumers to
run `cosign verify` with no version stated - so **our own documented command
reports our own images as unsigned**.

This cost real debugging time today before the cause was identified.

## Changes

**1. Pin the binary**, using the Renovate annotation convention already used for
zizmor:

```yaml
with:
  # renovate: datasource=github-releases depName=sigstore/cosign
  cosign-release: v3.0.6
```

Format changes now arrive as a reviewable PR.

**2. Sign in both storage formats** so consumers on either cosign major can
verify. They cannot collide - confirmed by enumerating all 240 tags on the live
`nodejs-24-base-linux-amd64` repo:

```
sha256-<digest>.sig    legacy format      (cosign 2.x and 3.x)
sha256-<digest>        bundle / referrers (cosign 3.x only)
```

Older images carry **both** tags. `v0.0.55` carries only the unsuffixed one -
which is exactly why v2 clients cannot see it.

**3. Verify after signing**, in both formats, as a hard gate. `cosign sign`
exiting 0 was never evidence the result is discoverable. This asserts the
invariant instead of trusting the exit code, and would have caught the format
change on the release that introduced it. Same assert-the-invariant pattern used
in the FIPS image build gates.

**4. Documentation** in README and the release-body template now states that
images are signed in both formats, how to target one explicitly, and that
signatures published before 2026-08-26 exist only in the bundle format.

## Validation

- `yamllint`, `actionlint`, `act --list` all clean
- zizmor clean at both `regular` and `pedantic` personas
- `gitleaks` no leaks, non-ASCII zero
- Format non-collision verified empirically against the live registry rather
  than assumed

The dual-signing itself cannot be fully exercised until a release tag is cut,
since keyless signing needs GitHub OIDC. The new verification gate is what
proves it: if either format fails to publish, the job fails rather than shipping
a half-verifiable image.

## Not included

The retry on `cosign sign` and the sign-before-publish ordering fix are
deliberately deferred - they are recorded in a separate plan.
