### PR TITLE
Revert dual-format cosign signing; it is not possible on v3

### DIFF
--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -367,16 +367,17 @@ jobs:
           for tag in ${TAGS}; do
             images+="${tag}@${DIGEST} "
           done
-          # Sign twice, once per storage format, so consumers on either cosign
-          # major can verify. The two cannot collide: the legacy format writes a
-          # "sha256-<digest>.sig" tag, while the Sigstore bundle format writes
-          # the "sha256-<digest>" referrers-fallback tag.
-          #   --new-bundle-format=false  readable by cosign v2.x and v3.x
-          #   --new-bundle-format=true   the v3 default, invisible to v2.x
+          # Single format, deliberately. Dual-format signing was attempted and
+          # does not work on cosign v3: --use-signing-config defaults to true and
+          # requires --new-bundle-format, so the legacy format is unreachable
+          # from the default keyless path. Passing --new-bundle-format=false
+          # fails with:
+          #   must provide --new-bundle-format or --bundle where applicable
+          #   with --signing-config or --use-signing-config
+          # Consequence for consumers: cosign 2.x cannot verify these images and
+          # reports "no signatures found". Verify with cosign 3.x. See README.
           # shellcheck disable=SC2086
-          cosign sign --yes --new-bundle-format=false ${images}
-          # shellcheck disable=SC2086
-          cosign sign --yes --new-bundle-format=true ${images}
+          cosign sign --yes ${images}
 
       - name: Verify signatures are discoverable in both formats
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -392,15 +393,11 @@ jobs:
           # is what would have caught the silent v2 -> v3 format change: the
           # sign step stayed green while the published signature became
           # undiscoverable to half the clients that verify it.
-          for fmt in false true; do
-            echo "== verifying with --new-bundle-format=${fmt}"
-            cosign verify \
-              --new-bundle-format="${fmt}" \
-              --certificate-identity-regexp "https://github.com/${CTX_REPOSITORY}/.github/workflows/.*" \
-              --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
-              "${ref}" > /dev/null
-          done
-          echo "OK: verifies in both the legacy and Sigstore bundle formats"
+          cosign verify \
+            --certificate-identity-regexp "https://github.com/${CTX_REPOSITORY}/.github/workflows/.*" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${ref}" > /dev/null
+          echo "OK: signature is present and verifies with the pinned cosign"
 
       - name: Generate artifact attestation
         if: github.event_name == 'push' && github.ref_type == 'tag'
@@ -530,9 +527,9 @@ jobs:
             ${registry}/${repo_name}/${image_base_name}-linux-arm64:latest
           \`\`\`
 
-          Signed in both cosign storage formats, so any cosign 2.x or 3.x client
-          can verify. To target one explicitly, pass \`--new-bundle-format=false\`
-          for the legacy format or \`=true\` for the Sigstore bundle format.
+          Requires **cosign 3.x**. These images are signed with cosign 3, whose
+          Sigstore bundle format is not discoverable by cosign 2.x - a 2.x client
+          reports \`no signatures found\` against a correctly signed image.
 
           **Verify with GitHub CLI:**
           \`\`\`bash

--- a/README.md
+++ b/README.md
@@ -78,15 +78,11 @@ cosign verify \
   ghcr.io/interrzero/base-docker-images/wolfi-base-linux-amd64:latest
 ```
 
-Images are signed in **both** cosign storage formats, so any cosign 2.x or 3.x
-client can verify them. If you need to target one explicitly, pass
-`--new-bundle-format=false` for the legacy format or `=true` for the Sigstore
-bundle format.
-
-> Signatures published before 2026-08-26 exist only in the Sigstore bundle
-> format and are **not** discoverable by cosign 2.x, which reports
-> `no signatures found` against a correctly signed image. Verify those with
-> cosign 3.x.
+> **Verify with cosign 3.x.** Images are signed with cosign 3, whose Sigstore
+> bundle format is not discoverable by cosign 2.x. A 2.x client reports
+> `no signatures found` against a correctly signed image. Dual-format signing is
+> not available: cosign 3 requires `--new-bundle-format` whenever a signing
+> config is in use, which is the default for keyless signing.
 
 **Using GitHub CLI:**
 ```bash


### PR DESCRIPTION
**Fixes a broken publish pipeline. #391 made signing fail on every image.**

## What broke

`wolfi-base v1.1.139` failed on both arches at the signing step:

```
Error: must provide --new-bundle-format or --bundle where applicable
       with --signing-config or --use-signing-config
```

## Why the dual-format premise was wrong

On cosign v3.0.6, `--use-signing-config` **defaults to true**, and its own help
text says it *"Must set --new-bundle-format"*. So the legacy format is
unreachable from the default keyless signing path, and `--new-bundle-format=false`
is a hard error rather than a fallback to the old behaviour.

The registry evidence in #391 was correct - the two formats do occupy different
tags and cannot collide - but that only establishes they *could* coexist, not
that cosign v3 is willing to write both. I did not verify the second claim
before shipping, because the flag combination could not be exercised locally
(keyless needs GitHub OIDC, and `--tlog-upload=false` conflicts with the
new-format path).

## This change

- Revert to a single `cosign sign` call, with the finding recorded inline so the
  approach is not retried
- **Keep** the `cosign-release: v3.0.6` pin from #391 - that was the actual root
  cause fix and is unaffected
- **Keep** the post-sign verification gate, narrowed to the one format that
  exists
- Correct README and the release-body template, which claimed "signed in both
  formats" - never true

## Consumer impact

Unchanged from before #391, but now stated honestly: **verifying these images
requires cosign 3.x**. A 2.x client reports `no signatures found` against a
correctly signed image.

## Cleanup needed after merge

`wolfi-base v1.1.139` was pushed before signing failed, so its tags moved onto an
unsigned image - the same partial-publish state as `nodejs-24-base v0.0.54`.
Re-running that tag repairs it once this lands: the already-published guard is a
no-op, so a re-run rebuilds, re-pushes and signs.

## Urgency

The daily rebuild runs at 10:00 UTC. Without this, every image it touches will
push and then fail to sign.
