### PR TITLE
Sign before tagging, retry signing, and make the publish guard real

### DIFF
--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -207,11 +207,19 @@ jobs:
             echo "image_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # Note: "exit 0" ends this step, not the job. The skip is enforced by the
+      # image_exists condition on each step below, not here. Before that gating
+      # existed this guard did nothing at all and every re-run rebuilt from
+      # scratch, which on the emulated arm64 leg costs about an hour.
+      #
+      # The check is trustworthy now that tags are applied only after signing
+      # and verification: if the version tag exists, the publish completed in
+      # full. A partially published tag has no version tag, so a re-run
+      # correctly rebuilds and repairs it.
       - name: Exit early if image already published
         if: github.event_name == 'push' && github.ref_type == 'tag' && steps.image_exists.outputs.image_exists == 'true'
         run: |
-          echo "Image already published for this tag, skipping build."
-          exit 0
+          echo "Image already published and signed for this tag; skipping build and publish."
 
       - name: Setup Docker environment
         uses: ./.github/actions/setup-docker
@@ -332,20 +340,26 @@ jobs:
       # Push image only after all tests and security scans pass
       - name: Push Docker Image for ${{ matrix.platform }}
         id: push
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && steps.image_exists.outputs.image_exists != 'true'
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           file: Dockerfile.${{ needs.generate-matrix.outputs.image-base-name }}
           platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: mode=max
           sbom: true
           cache-from: type=gha,scope=${{ github.repository }}-${{ needs.generate-matrix.outputs.image-base-name }}
+          # Pushed by digest with NO tags. The consumer-facing tags are applied
+          # further down, only after signing and verification have succeeded, so
+          # a signing failure can never leave "latest" pointing at an unsigned
+          # image. Previously all four tags moved here, before signing, and a
+          # transient OIDC failure did exactly that.
+          # push-by-digest needs the docker-container driver, which
+          # setup-buildx-action provides.
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.context.outputs.image-name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Install cosign
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && steps.image_exists.outputs.image_exists != 'true'
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
           # Pin the cosign BINARY, not just the action. Left unset, the installer
@@ -358,7 +372,7 @@ jobs:
           cosign-release: v3.0.6
 
       - name: Sign container image with cosign
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && steps.image_exists.outputs.image_exists != 'true'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
@@ -376,11 +390,28 @@ jobs:
           #   with --signing-config or --use-signing-config
           # Consequence for consumers: cosign 2.x cannot verify these images and
           # reports "no signatures found". Verify with cosign 3.x. See README.
-          # shellcheck disable=SC2086
-          cosign sign --yes ${images}
+          # Retry: keyless signing depends on GitHub's OIDC endpoint, which has
+          # been observed returning a non-JSON body and failing a publish that
+          # was otherwise complete. Six of seven images signed fine in the same
+          # minute, so a transient blip should not sink the release.
+          attempt=1
+          until [ "$attempt" -gt 3 ]; do
+            # shellcheck disable=SC2086
+            if cosign sign --yes ${images}; then
+              echo "signed on attempt ${attempt}"
+              break
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              echo "cosign sign failed after 3 attempts" >&2
+              exit 1
+            fi
+            echo "cosign sign failed (attempt ${attempt}), retrying in $((attempt * 10))s" >&2
+            sleep "$((attempt * 10))"
+            attempt=$((attempt + 1))
+          done
 
-      - name: Verify signatures are discoverable in both formats
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+      - name: Verify the signature is present and verifiable
+        if: github.event_name == 'push' && github.ref_type == 'tag' && steps.image_exists.outputs.image_exists != 'true'
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
           CTX_IMAGE_NAME: ${{ steps.context.outputs.image-name }}
@@ -400,12 +431,41 @@ jobs:
           echo "OK: signature is present and verifies with the pinned cosign"
 
       - name: Generate artifact attestation
-        if: github.event_name == 'push' && github.ref_type == 'tag'
+        if: github.event_name == 'push' && github.ref_type == 'tag' && steps.image_exists.outputs.image_exists != 'true'
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/${{ steps.context.outputs.image-name }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
+
+      - name: Apply consumer tags now that the image is signed
+        if: github.event_name == 'push' && github.ref_type == 'tag' && steps.image_exists.outputs.image_exists != 'true'
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          CTX_IMAGE_NAME: ${{ steps.context.outputs.image-name }}
+          CTX_REPOSITORY: ${{ github.repository }}
+          CTX_REGISTRY: ${{ env.REGISTRY }}
+        run: |
+          set -eu
+          # This is the step that makes the image visible to consumers. It runs
+          # last, so everything a tag implies - built, tested, scanned, signed,
+          # verified, attested - is already true by the time the tag exists.
+          # If any earlier step fails, all that remains is an untagged manifest:
+          # unreachable by tag and garbage-collectable.
+          #
+          # imagetools create preserves the OCI index produced by the build
+          # (image manifest plus attestation manifest), which the
+          # create_multiarch_manifests job depends on when it resolves
+          # per-architecture digests.
+          tag_args=""
+          for tag in ${TAGS}; do
+            tag_args="${tag_args} -t ${tag}"
+          done
+          src="${CTX_REGISTRY}/${CTX_REPOSITORY}/${CTX_IMAGE_NAME}@${DIGEST}"
+          echo "tagging ${src}"
+          # shellcheck disable=SC2086
+          docker buildx imagetools create ${tag_args} "${src}"
 
       - name: Extract language versions
         id: extract_versions

--- a/.github/workflows/publish-base-images.yml
+++ b/.github/workflows/publish-base-images.yml
@@ -572,6 +572,16 @@ jobs:
 
           Platform-specific images include full SLSA provenance attestations (\`provenance: mode=max\`) and SBOM.
 
+          > **Verify against the platform-specific tags below, not the
+          > multi-architecture tag.** Signatures and attestations are attached to
+          > \`${image_base_name}-linux-amd64\` and \`${image_base_name}-linux-arm64\`
+          > during the build. The multi-architecture tag
+          > \`${image_base_name}:latest\` is a manifest list assembled afterwards
+          > and carries neither, so verifying it returns \`HTTP 404\` even though
+          > the images it points to are properly signed. Pulling the
+          > multi-architecture tag is fine; only verification needs the
+          > platform-specific reference.
+
           **Verify image signatures (cosign):**
           \`\`\`bash
           # AMD64

--- a/README.md
+++ b/README.md
@@ -68,7 +68,22 @@ All images are built with supply chain security features:
 
 ### Verify Image Signatures
 
-Platform-specific images (`-linux-amd64`, `-linux-arm64`) include full attestations.
+> **Verify against the platform-specific tags**, not the multi-architecture one.
+> Signatures and attestations are attached to `<image>-linux-amd64` and
+> `<image>-linux-arm64` during the build. The multi-architecture tag
+> (`<image>:latest`) is a manifest list assembled afterwards and carries neither,
+> so verifying it fails even though the images it points to are properly signed:
+>
+> ```
+> gh attestation verify oci://ghcr.io/.../wolfi-base:latest        -> HTTP 404
+> gh attestation verify oci://ghcr.io/.../wolfi-base-linux-amd64:latest  -> verified
+> ```
+>
+> Pull whichever tag suits you; the multi-architecture one is fine for that. Only
+> the verification commands need the platform-specific reference.
+
+Every example below uses a `-linux-amd64` tag for that reason. Substitute
+`-linux-arm64` to verify the other architecture.
 
 **Using cosign:**
 ```bash


### PR DESCRIPTION
Implements the deferred plan, plus the misleading step name.

## 1. Tags moved before the signature existed

`build-push-action` published all four tags (version, major, minor, `latest`)
and signing ran afterwards. Consumer tags therefore resolved to an unsigned
image for the duration of the signing step - and when signing failed, that state
persisted. Both **nodejs-24-base v0.0.54** and **wolfi-base v1.1.139** were left
pushed, unsigned, with `latest` moved onto them.

Now: pushed **by digest with no tags**, and the consumer tags are applied in a
new final step that runs only after signing, verification *and* attestation have
succeeded.

```
push (by digest, untagged)
  -> sign (with retry)
  -> verify
  -> attest
  -> apply consumer tags     <- the image becomes visible here
```

A failure anywhere in that chain now leaves an untagged manifest: unreachable by
tag, garbage-collectable, invisible to consumers.

### Verified locally first

The last publish-path change I shipped was based on an assumption and broke the
pipeline. This one was tested against a real registry before being written:

```
push-by-digest      -> NO tags applied
imagetools create   -> manifests=2 platforms=[amd64,unknown]   (identical to today)
manifest job's jq   -> amd64 digest resolves correctly
```

That third one matters: `create_multiarch_manifests` does
`docker manifest inspect ... | jq '.manifests[] | select(.platform.architecture=="amd64")'`,
so the tag must keep resolving to an OCI index. It does.

`push-by-digest` needs the docker-container driver, which `setup-buildx-action`
already provides.

## 2. No retry on signing

Keyless signing depends on GitHub's OIDC endpoint, which returned a non-JSON
body and killed an otherwise complete publish. Six of seven images signed in the
same minute, so it was transient. Signing now retries 3x with backoff.

## 3. The "already published" guard did nothing

`image_exists` was computed and referenced in exactly one `if:` - on the
early-exit step itself. `exit 0` ends a *step*, not a job, and nothing else was
gated on it, so every re-run of a published tag rebuilt and re-pushed in full.

The six publish steps are now gated on it. The check is also trustworthy for the
first time: since tags are applied only after signing, **a version tag existing
means the publish completed in full**, and a partially published tag has no
version tag - so a re-run correctly repairs it.

## 4. Misleading gate name

The verification step still read "Verify signatures are discoverable in both
formats" after dual-format signing was reverted. Renamed.

## Deliberately not included

Build and test steps are not gated on `image_exists`. The build step has no
`if:` at all because it must run on pull requests. Skipping those on a re-run
would save the ~1h arm64 emulation, but that is an optimisation, not a
correctness fix, and this PR is already touching the publish path.

## Validation and residual risk

`yamllint`, `actionlint`, `act --list`, `gitleaks`, non-ASCII, and zizmor at both
`regular` and `pedantic` all clean.

The push/sign/tag path only executes on a release tag - PR CI skips it by design
- so like any change here it is first exercised post-merge. The failure mode is
now benign though: if anything is wrong, no tags move and no consumer sees a bad
image. I'd still suggest validating on `wolfi-base` (cheapest build) before the
10:00 UTC fleet rebuild.
